### PR TITLE
[#98] main 브랜치 빌드 검증

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,10 +30,13 @@ jobs:
     - name: Create GoogleService-Info.plist
       run: |
         mkdir -p ./Damago/Damago/Resources
+        
+        # Dev 파일은 빌드 검증(Debug)을 위해 항상 생성
+        echo "${{ secrets.GOOGLE_SERVICE_INFO_PLIST_DEV_BASE64 }}" | base64 --decode > ./Damago/Damago/Resources/GoogleService-Info-Dev.plist
+        
+        # Main 브랜치인 경우 Release 빌드를 위해 Prod 파일 추가 생성
         if [ "${{ github.ref }}" == "refs/heads/main" ]; then
           echo "${{ secrets.GOOGLE_SERVICE_INFO_PLIST_PROD_BASE64 }}" | base64 --decode > ./Damago/Damago/Resources/GoogleService-Info-Prod.plist
-        else
-          echo "${{ secrets.GOOGLE_SERVICE_INFO_PLIST_DEV_BASE64 }}" | base64 --decode > ./Damago/Damago/Resources/GoogleService-Info-Dev.plist
         fi
 
     - name: Run Fastlane Tests


### PR DESCRIPTION
Always create Dev plist for build validation and conditionally create Prod plist for main branch.

## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)를 적어주세요. 해당 이슈가 존재하지 않으면 생략 가능합니다.-->
- resolves #98 

- fastlane은 Debug 빌드 이후 Release 빌드 검증
  - 따라서 Debug.plist가 항상 존재해야함