### PR TITLE
[#48] 라이브 액티비티 밥주기 버튼 활성화

### DIFF
--- a/Damago/Damago.xcodeproj/project.pbxproj
+++ b/Damago/Damago.xcodeproj/project.pbxproj
@@ -96,6 +96,7 @@
 			membershipExceptions = (
 				Sources/AppIntent/BackToIdleAppIntent.swift,
 				Sources/AppIntent/ChoosePokeMessageAppIntent.swift,
+				Sources/AppIntent/FeedAppIntent.swift,
 				Sources/AppIntent/PokeAppIntent.swift,
 				Sources/AppIntent/PokeWithMessageAppIntent.swift,
 			);

--- a/Damago/DamagoWidget/Sources/AppIntent/FeedAppIntent.swift
+++ b/Damago/DamagoWidget/Sources/AppIntent/FeedAppIntent.swift
@@ -7,15 +7,137 @@
 
 import AppIntents
 import Foundation
+import DamagoNetwork
+import OSLog
+import ActivityKit
 
-struct FeedAppIntent: AppIntent {
+struct FeedAppIntent: AppIntent, LiveActivityIntent {
     static var title: LocalizedStringResource = "밥 주기"
     static var description: IntentDescription = "다마고에게 밥을 줍니다."
 
+    @Parameter(title: "Live Activity ID")
+    var activityID: String
+
+    @Dependency var networkProvider: NetworkProvider
+    @Dependency var tokenProvider: TokenProvider
+
     init() { }
 
+    init(activityID: String) {
+        self.activityID = activityID
+    }
+
     func perform() async throws -> some IntentResult {
-        // 밥주기 구현
-        return .result()
+        await setScreen(.sending)
+
+        do {
+            let token = try await fetchIDToken()
+            let userInfo = try await fetchUserInfo(accessToken: token)
+
+            guard let damagoID = userInfo.damagoID else {
+                await showTransientErrorAndReturnIdle(logMessage: "User info doesn't have damago id")
+                return .result()
+            }
+
+            try await requestFeed(accessToken: token, damagoID: damagoID)
+
+            // feed 성공 후 서버의 최신 PetStatus로 Live Activity 상태 동기화
+            guard let petStatus = try await fetchPetStatus(accessToken: token) else {
+                await showTransientErrorAndReturnIdle()
+                return .result()
+            }
+
+            await applyPetStatusAndReturnIdle(petStatus)
+            return .result()
+        } catch {
+            await SharedLogger.liveActivityAppIntent
+                .error("Feed request failed: \(String(describing: error))")
+
+            await showTransientErrorAndReturnIdle()
+            return .result()
+        }
+    }
+
+    /// 현재 Live Activity를 찾아서, 최신 ContentState를 가져온 뒤 변경을 적용하고 업데이트합니다.
+    @MainActor
+    private func updateState(_ mutate: (inout DamagoAttributes.ContentState) -> Void) async {
+        guard let activity = Activity<DamagoAttributes>.activities.first(where: { $0.id == activityID }) else {
+            SharedLogger.liveActivityAppIntent
+                .error("live activity id match failed: \(activityID)")
+            return
+        }
+
+        var next = activity.content.state
+        mutate(&next)
+
+        await activity.update(ActivityContent(state: next, staleDate: nil))
+    }
+
+    /// Live Activity 화면 상태(`screen`)만 변경합니다.
+    private func setScreen(_ screen: DamagoAttributes.Screen) async {
+        await updateState { $0.screen = screen }
+    }
+
+    /// 인증 토큰(ID Token)을 가져옵니다.
+    private func fetchIDToken() async throws -> String {
+        try await tokenProvider.idToken()
+    }
+
+    /// 사용자 정보를 서버에서 조회합니다.
+    private func fetchUserInfo(accessToken: String) async throws -> UserInfoResponse {
+        try await networkProvider.request(
+            UserAPI.getUserInfo(accessToken: accessToken)
+        )
+    }
+
+    /// 서버에 feed 요청을 전송합니다.
+    private func requestFeed(accessToken: String, damagoID: String) async throws {
+        _ = try await networkProvider.requestSuccess(
+            PetAPI.feed(accessToken: accessToken, damagoID: damagoID)
+        )
+    }
+
+    /// 최신 PetStatus를 얻기 위해 UserInfo를 재조회하고, petStatus만 반환합니다.
+    /// - Returns: 서버 응답에 petStatus가 없으면 nil을 반환합니다.
+    private func fetchPetStatus(accessToken: String) async throws -> DamagoStatusResponse? {
+        let refreshedUserInfo: UserInfoResponse = try await fetchUserInfo(accessToken: accessToken)
+
+        guard let petStatus = refreshedUserInfo.petStatus else {
+            await SharedLogger.liveActivityAppIntent
+                .error("User info doesn't have pet status")
+            return nil
+        }
+
+        return petStatus
+    }
+
+    /// 서버에서 받은 PetStatus로 ContentState를 재구성하고, 화면을 idle로 복귀시킵니다.
+    private func applyPetStatusAndReturnIdle(_ petStatus: DamagoStatusResponse) async {
+        await updateState { state in
+            state = DamagoAttributes.ContentState(
+                petType: petStatus.petType,
+                isHungry: petStatus.isHungry,
+                statusMessage: petStatus.statusMessage,
+                level: petStatus.level,
+                currentExp: petStatus.currentExp,
+                maxExp: petStatus.maxExp,
+                lastFedAt: petStatus.lastFedAt
+            )
+            state.screen = .idle
+        }
+    }
+
+    /// 에러 화면을 잠깐 노출한 뒤, idle로 복귀시킵니다.
+    private func showTransientErrorAndReturnIdle(
+        logMessage: String? = nil,
+        delayNanoseconds: UInt64 = 1_200_000_000
+    ) async {
+        if let logMessage {
+            await SharedLogger.liveActivityAppIntent.error("\(logMessage)")
+        }
+
+        await setScreen(.error)
+        try? await Task.sleep(nanoseconds: delayNanoseconds)
+        await setScreen(.idle)
     }
 }

--- a/Damago/DamagoWidget/Sources/DamagoWidgetLiveActivity.swift
+++ b/Damago/DamagoWidget/Sources/DamagoWidgetLiveActivity.swift
@@ -146,13 +146,13 @@ struct DamagoWidgetLiveActivity: Widget {
 
     private func actionButtonsView(activityID: String) -> some View {
         VStack(spacing: .spacingS) {
-            feedButton()
+            feedButton(activityID: activityID)
             pokeButton(activityID: activityID)
         }
     }
 
-    private func feedButton() -> some View {
-        Button(intent: FeedAppIntent()) {
+    private func feedButton(activityID: String) -> some View {
+        Button(intent: FeedAppIntent(activityID: activityID)) {
             HStack(spacing: .spacingS) {
                 Image(systemName: "fork.knife")
                     .foregroundStyle(feedButtonIconColor)


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)를 적어주세요. 해당 이슈가 존재하지 않으면 생략 가능합니다.-->
- resolves #48 

## 🥑 작업 요약
라이브 액티비티에서 밥을 줄 수 있도록 app intent를 구현했습니다.
<!-- 이번 PR에서 작업한 내용을 간략하게 설명해주세요.-->

## 🛠️ 작업 내용

찌르기와 동일한 형식으로 네트워크 요청 및 보내기, 에러 화면 전환을 처리했습니다.

<!-- 어떻게 보다는 '왜' 이렇게 수정했는지, 의도를 중심으로 작성해주세요.
- 개발 과정에서 발생한 문제와 해결 방법, 대안 등을 정리하면 좋습니다.-->

## 📸 스크린샷 (UI 변경 시)
<!-- UI 변경 사항이 있다면 필수입니다. -->
| 전체 동작 | 밥주기 | 전송 중 화면에서 탈출 |
| :--: | :--: | :--: |
![2026-01-19 18 00 06](https://github.com/user-attachments/assets/d2b23beb-52dd-4dfe-b301-390247f62aad)|![2026-01-19 18 03 27](https://github.com/user-attachments/assets/19176334-ea98-43b3-b4e6-56543384b723)|![2026-01-19 18 02 39](https://github.com/user-attachments/assets/fc32e4ee-c7c8-4ca2-9a7b-6f4a88e78f61)
## 🧪 테스트 방법
<!-- 리뷰어가 변경 사항을 확인할 수 있는 방법을 서술합니다. -->
기존 연결되어있던 페어 코드를 입력하여 시뮬레이터에서 수행해보았습니다.

## 💬 리뷰 요구사항 (Optional)
메서드 길이가 너무 길다는 경고가 발생하여 저수준 로직을 모두 분리해봤습니다.  
`perform()`에는 고수준 코드만 남겨두고, 직접적으로 객체에 요청하거나 상태를 변경하는 코드는 다 별도로 존재하는데 네이밍이나 가독성 면에서 어떤지 봐주시면 좋을 듯 합니다.  
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
예: 메서드 XXX의 이름이 직관적인지, 리팩토링 방식이 적절한지 등 -->

## ✅ 체크리스트
- [x] 빌드 및 실행 테스트를 완료했나요?
- [x] 불필요한 주석 및 Print 문을 제거했나요?
- [x] 코딩 컨벤션을 준수했나요?
