### PR TITLE
[#115] fix: 200자 제한

### DIFF
--- a/Damago/Damago/Sources/Presentation/Features/Interaction/DailyQuestion/DailyQuestionInputViewController.swift
+++ b/Damago/Damago/Sources/Presentation/Features/Interaction/DailyQuestion/DailyQuestionInputViewController.swift
@@ -30,6 +30,7 @@ final class DailyQuestionInputViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         setupNavigation()
+        setupTextView()
         setupKeyboard()
         
         mainView.configure(title: viewModel.question)
@@ -52,6 +53,10 @@ final class DailyQuestionInputViewController: UIViewController {
     private func setupNavigation() {
         title = "오늘의 질문"
         navigationItem.largeTitleDisplayMode = .never
+    }
+    
+    private func setupTextView() {
+        mainView.textView.delegate = self
     }
     
     private func setupKeyboard() {
@@ -90,5 +95,14 @@ final class DailyQuestionInputViewController: UIViewController {
             
             view.endEditing(true)
         }
+    }
+}
+
+extension DailyQuestionInputViewController: UITextViewDelegate {
+    func textView(_ textView: UITextView, shouldChangeTextIn range: NSRange, replacementText text: String) -> Bool {
+        guard let currentText = textView.text else { return true }
+        guard let stringRange = Range(range, in: currentText) else { return false }
+        let updatedText = currentText.replacingCharacters(in: stringRange, with: text)
+        return updatedText.count <= 200
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)를 적어주세요. 해당 이슈가 존재하지 않으면 생략 가능합니다.-->
- resolves #115 

## 🥑 작업 요약
<!-- 이번 PR에서 작업한 내용을 간략하게 설명해주세요.-->
- UI에서 200자 제한

## 🛠️ 작업 내용
<!-- 어떻게 보다는 '왜' 이렇게 수정했는지, 의도를 중심으로 작성해주세요.
- 개발 과정에서 발생한 문제와 해결 방법, 대안 등을 정리하면 좋습니다.-->

### DailyQuestionInputViewController
- `ViewModel`의 `handleTextChange` 에서는 200자 truncated 로직을 진행하고 있었습니다.
- `UITextDelegate`를 채택하여 `TextView`의 편집 가능 유무를 UI 적으로 제한하였습니다.

## 📸 스크린샷 (UI 변경 시)

https://github.com/user-attachments/assets/e813cf51-6353-4811-b46f-61e61ccf73b6


## 🧪 테스트 방법
<!-- 리뷰어가 변경 사항을 확인할 수 있는 방법을 서술합니다. -->
- 상호작용 탭의 답변제출을 클릭한 뒤 200 자 이상 입력해봅니다.

## ✅ 체크리스트
- [x] 빌드 및 실행 테스트를 완료했나요?
- [x] 불필요한 주석 및 Print 문을 제거했나요?
- [x] 코딩 컨벤션을 준수했나요?
