### PR TITLE
[#210] 상호작용 기본 카드 화면에 문구 추가

### DIFF
--- a/Damago/Damago/Sources/Presentation/Features/Interaction/InteractionView.swift
+++ b/Damago/Damago/Sources/Presentation/Features/Interaction/InteractionView.swift
@@ -125,6 +125,22 @@ final class InteractionView: UIView {
         view.layer.shadowOffset = CGSize(width: 0, height: 10)
         view.layer.shadowRadius = 20
         view.translatesAutoresizingMaskIntoConstraints = false
+        
+        let label = UILabel()
+        label.text = "\"질문을 불러오는 중...\""
+        label.font = .body1
+        label.textColor = .textSecondary
+        label.textAlignment = .center
+        label.translatesAutoresizingMaskIntoConstraints = false
+        
+        view.addSubview(label)
+        NSLayoutConstraint.activate([
+            label.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            label.centerYAnchor.constraint(equalTo: view.centerYAnchor),
+            label.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: .spacingL),
+            label.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -.spacingL)
+        ])
+        
         return view
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)를 적어주세요. 해당 이슈가 존재하지 않으면 생략 가능합니다.-->
- resolves #210 

## 🥑 작업 요약
<!-- 이번 PR에서 작업한 내용을 간략하게 설명해주세요.-->
- 상호작용 화면 카드 뷰에 문구를 추가했습니다.
## 🛠️ 작업 내용
- balance game에만 한정된 로딩 뷰 추가보다 공통적으로 재사용할 `makeCardView()`에 문구를 추가하는 것이 더 효율적이라 판단되었습니다.
<!-- 어떻게 보다는 '왜' 이렇게 수정했는지, 의도를 중심으로 작성해주세요.
- 개발 과정에서 발생한 문제와 해결 방법, 대안 등을 정리하면 좋습니다.-->

## 📸 스크린샷 (UI 변경 시)
<img width="286" height="327" alt="7B3340AF-869D-4A7C-A69A-3B07560F5899" src="https://github.com/user-attachments/assets/0ef1faa3-4ac1-4973-ba8b-eeab6d4f298a" />


## 🧪 테스트 방법
<!-- 리뷰어가 변경 사항을 확인할 수 있는 방법을 서술합니다. -->
새로운 질문을 받아올 때 확인 가능합니다. 
## ✅ 체크리스트
- [x] 빌드 및 실행 테스트를 완료했나요?
- [x] 불필요한 주석 및 Print 문을 제거했나요?
- [x] 코딩 컨벤션을 준수했나요?
