### PR TITLE
[#170] 먹이주기 액티비티 업데이트 및 Fallback

### DIFF
--- a/DamagoFirebase/functions/services/pet_service.py
+++ b/DamagoFirebase/functions/services/pet_service.py
@@ -119,7 +119,8 @@ def feed(req: https_fn.Request) -> https_fn.Response:
             "user1UID": user1,
             "user2UID": user2,
             "petType": data.get("petType", "Bunny"),
-            "statusMessage": update_data["statusMessage"]
+            "statusMessage": update_data["statusMessage"],
+            "petName": data.get("petName", "이름 없는 펫")
         }
 
     try:
@@ -142,10 +143,14 @@ def feed(req: https_fn.Request) -> https_fn.Response:
                 "maxExp": result.get("maxExp"),
                 "lastFedAt": now_str
             }
+            
+            attributes = {
+                "petName": result.get("petName")
+            }
 
             for target_uid in users:
                 if target_uid:
-                    update_live_activity_internal(target_uid, content_state)
+                    update_live_activity_internal(target_uid, content_state, attributes)
                     
         except Exception as la_error:
             print(f"Failed to update Live Activity: {la_error}")
@@ -288,8 +293,12 @@ def make_hungry(req: https_fn.Request) -> https_fn.Response:
                 "lastFedAt": last_fed_at_str
             }
             
+            attributes = {
+                "petName": pet_data.get("petName", "이름 없는 펫")
+            }
+            
             for uid in users:
                 if uid:
-                    update_live_activity_internal(uid, content_state)
+                    update_live_activity_internal(uid, content_state, attributes)
 
     return https_fn.Response("Made hungry and notified", status=200)

--- a/DamagoFirebase/functions/services/push_service.py
+++ b/DamagoFirebase/functions/services/push_service.py
@@ -123,9 +123,10 @@ def update_live_activity(req: https_fn.Request) -> https_fn.Response:
         return https_fn.Response("Live Activity update skipped or failed", status=200)
 
 
-def update_live_activity_internal(target_uid: str, content_state: dict) -> bool:
+def update_live_activity_internal(target_uid: str, content_state: dict, attributes: dict = None) -> bool:
     """
-    내부 호출용 Live Activity 업데이트 함수
+    내부 호출용 Live Activity 업데이트 함수.
+    업데이트 실패 시, attributes와 Start Token이 있다면 새로운 Activity를 시작합니다.
     """
     db = get_db()
 
@@ -137,44 +138,87 @@ def update_live_activity_internal(target_uid: str, content_state: dict) -> bool:
 
     user_data = user_doc.to_dict()
     fcm_token = user_data.get("fcmToken")
-    la_token = user_data.get("laUpdateToken")
+    la_update_token = user_data.get("laUpdateToken")
+    la_start_token = user_data.get("laStartToken")
     use_live_activity = user_data.get("useLiveActivity", True)
 
-    if not fcm_token or not la_token or not use_live_activity:
-        print(f"Live Activity not active for {target_uid}")
+    if not fcm_token or not use_live_activity:
+        print(f"Live Activity not active (or no FCM token) for {target_uid}")
         return False
 
-    try:
-        aps = messaging.Aps(
-            alert=messaging.ApsAlert(
-                title="다마고 상태 변경",
-                body="다마고치가 반응했어요!"
-            ),
-            custom_data={
-                "event": "update",
-                "timestamp": int(time.time()),
-                "content-state": content_state
-            }
-        )
-
-        message = messaging.Message(
-            token=fcm_token,
-            apns=messaging.APNSConfig(
-                live_activity_token=la_token,
-                headers={
-                    "apns-push-type": "liveactivity",
-                    "apns-topic": f"{BUNDLE_ID}.push-type.liveactivity",
-                    "apns-priority": "10"
-                },
-                payload=messaging.APNSPayload(aps=aps)
+    # 1. Update 시도
+    if la_update_token:
+        try:
+            aps = messaging.Aps(
+                alert=messaging.ApsAlert(
+                    title="다마고 상태 변경",
+                    body="다마고치가 반응했어요!"
+                ),
+                custom_data={
+                    "event": "update",
+                    "timestamp": int(time.time()),
+                    "content-state": content_state
+                }
             )
-        )
-        response = messaging.send(message)
-        print(f"Live Activity update sent to {target_uid}: {response}")
-        return True
 
-    except Exception as e:
-        print(f"Error updating Live Activity: {e}")
+            message = messaging.Message(
+                token=fcm_token,
+                apns=messaging.APNSConfig(
+                    live_activity_token=la_update_token,
+                    headers={
+                        "apns-push-type": "liveactivity",
+                        "apns-topic": f"{BUNDLE_ID}.push-type.liveactivity",
+                        "apns-priority": "10"
+                    },
+                    payload=messaging.APNSPayload(aps=aps)
+                )
+            )
+            response = messaging.send(message)
+            print(f"Live Activity update sent to {target_uid}: {response}")
+            return True
+
+        except Exception as e:
+            print(f"Live Activity update failed for {target_uid}: {e}. Trying fallback to Start...")
+            # Fallback 진행을 위해 예외를 무시하고 아래로 진행
+    
+    # 2. Fallback: Start 시도 (Update 실패 혹은 토큰 없음)
+    if la_start_token and attributes:
+        try:
+            print(f"Attempting to START Live Activity for {target_uid} as fallback.")
+            aps = messaging.Aps(
+                alert=messaging.ApsAlert(
+                    title="다마고 알림",
+                    body=content_state.get("statusMessage", "새로운 상태가 도착했어요!")
+                ),
+                custom_data={
+                    "event": "start",
+                    "timestamp": int(time.time()),
+                    "content-state": content_state,
+                    "attributes": attributes,
+                    "attributes-type": "DamagoAttributes"
+                }
+            )
+
+            message = messaging.Message(
+                token=fcm_token,
+                apns=messaging.APNSConfig(
+                    live_activity_token=la_start_token,
+                    headers={
+                        "apns-push-type": "liveactivity",
+                        "apns-topic": f"{BUNDLE_ID}.push-type.liveactivity",
+                        "apns-priority": "10"
+                    },
+                    payload=messaging.APNSPayload(aps=aps)
+                )
+            )
+            response = messaging.send(message)
+            print(f"Live Activity started (fallback) for {target_uid}: {response}")
+            return True
+        except Exception as e:
+            print(f"Live Activity start (fallback) failed for {target_uid}: {e}")
+            return False
+    else:
+        print(f"Cannot fallback to Start: Missing start token or attributes for {target_uid}")
         return False
 
 


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)를 적어주세요. 해당 이슈가 존재하지 않으면 생략 가능합니다.-->
- resolves #170 

## 🥑 작업 요약
<!-- 이번 PR에서 작업한 내용을 간략하게 설명해주세요.-->
- 먹이주기시 액티비티를 상대방에게도 업데이트하여 포만감 동기화
- 업데이트 실패시 액티비티 시작 Fallback

## 🛠️ 작업 내용
<!-- 어떻게 보다는 '왜' 이렇게 수정했는지, 의도를 중심으로 작성해주세요.
- 개발 과정에서 발생한 문제와 해결 방법, 대안 등을 정리하면 좋습니다.-->

### Fallback
- update_live_activity_internal 함수를 수정하여 액티비티 업데이트 시도 후 Fallback 을 시도합니다.
- 수신자가 액티비티를 끄거나 시스템에 의해 종료된 경우 다시 띄워주어 먹이주기 및 배고픔 결과를 확실히 전달할 수 있게 됩니다.

## 📸 스크린샷 (UI 변경 시)
https://github.com/user-attachments/assets/13d85feb-7014-4529-a703-ba0a4775a7d3

## 🧪 테스트 방법
<!-- 리뷰어가 변경 사항을 확인할 수 있는 방법을 서술합니다. -->
- 에뮬레이터 환경에서 실기기와 시뮬레이터 간 커플 연결 후 진행

## ✅ 체크리스트
- [x] 빌드 및 실행 테스트를 완료했나요?
- [x] 불필요한 주석 및 Print 문을 제거했나요?
- [x] 코딩 컨벤션을 준수했나요?
