### PR TITLE
[#246] fcm토큰 업로드 보장

### DIFF
--- a/Damago/Damago/Sources/Data/Repository/UserRepository.swift
+++ b/Damago/Damago/Sources/Data/Repository/UserRepository.swift
@@ -8,6 +8,7 @@
 import Combine
 import DamagoNetwork
 import Foundation
+import OSLog
 
 final class UserRepository: UserRepositoryProtocol {
     private let networkProvider: NetworkProvider
@@ -52,11 +53,20 @@ final class UserRepository: UserRepositoryProtocol {
         return response.toDomain()
     }
     
-    func updateFCMToken(fcmToken: String) async throws {
-        let token = try await tokenProvider.idToken()
+    func updateFCMToken(fcmToken: String?) async throws {
+        guard let fcmToken = fcmToken ?? UserDefaults.standard.string(forKey: "fcmToken") else {
+            SharedLogger.apns.error("fcm 토큰을 가져오지 못했습니다.")
+            return
+        }
+
+        guard let idToken = try? await tokenProvider.idToken() else {
+            SharedLogger.apns.log("fcm 토큰 업데이트 중 id token을 가져오지 못했습니다. 로그인 상태가 아닙니다.")
+            return
+        }
+
         try await networkProvider.requestSuccess(
             UserAPI.updateFCMToken(
-                accessToken: token,
+                accessToken: idToken,
                 fcmToken: fcmToken
             )
         )

--- a/Damago/Damago/Sources/Domain/Protocols/UserRepositoryProtocol.swift
+++ b/Damago/Damago/Sources/Domain/Protocols/UserRepositoryProtocol.swift
@@ -12,7 +12,7 @@ protocol UserRepositoryProtocol {
     func generateCode() async throws -> ConnectionCodes
     func connectCouple(targetCode: String) async throws
     func getUserInfo() async throws -> UserInfo
-    func updateFCMToken(fcmToken: String) async throws
+    func updateFCMToken(fcmToken: String?) async throws
     func signIn() async throws
     func fcmToken() async throws -> String
     func observeCoupleSnapshot(coupleID: String) -> AnyPublisher<Result<CoupleSnapshotDTO, Error>, Never>

--- a/Damago/Damago/Sources/Domain/UseCase/SignInUseCase.swift
+++ b/Damago/Damago/Sources/Domain/UseCase/SignInUseCase.swift
@@ -18,5 +18,6 @@ final class SignInUseCaseImpl: SignInUseCase {
 
     func signIn() async throws {
         try await repository.signIn()
+        try await repository.updateFCMToken(fcmToken: nil)
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)를 적어주세요. 해당 이슈가 존재하지 않으면 생략 가능합니다.-->
- resolves #246

## 🥑 작업 요약
로그인 시 FCM 토큰이 최신 상태로 업데이트되도록 보장하고, 토큰 갱신 로직의 안정성을 개선했습니다.

## 🛠️ 작업 내용
- 기존 FCM 토큰 업데이트 누락 문제
  - `MessagingDelegate`의 `messaging(_ messaging: Messaging, didReceiveRegistrationToken fcmToken: String?)` 호출 시점에 로그인이 되어 있지 않은 경우, `TokenProvider`에서 `idToken`을 가져올 때 에러가 발생하고 fcm 토큰 업데이트가 실패합니다.
- **FCM 토큰 업데이트 로직 개선 (`UserRepository`)**
  - `updateFCMToken` 메서드의 파라미터를 `String?`으로 변경하여, 인자가 없을 경우 `UserDefaults`에 저장된 토큰을 사용하도록 수정했습니다.
  - 토큰이 없거나 로그인 상태가 아닐 때(ID 토큰 조회 실패 시) 적절한 에러 로그를 남기고 안전하게 종료하도록 가드문을 추가했습니다.
- **로그인 시 토큰 동기화 (`SignInUseCase`)**
  - `signIn` 성공 직후 `updateFCMToken(fcmToken: nil)`을 호출하여, 로그인 시점에 백엔드에 최신 FCM 토큰을 등록하도록 흐름을 추가했습니다.

## 🧪 테스트 방법
<!-- 리뷰어가 변경 사항을 확인할 수 있는 방법을 서술합니다. -->
- 시뮬레이터 로그아웃 후 테스트 가능합니다

## ✅ 체크리스트
- [x] 빌드 및 실행 테스트를 완료했나요?
- [x] 불필요한 주석 및 Print 문을 제거했나요?
- [x] 코딩 컨벤션을 준수했나요?
