### PR TITLE
[#252] 다마고 변경 시 로직에 반영

### DIFF
--- a/Damago/Damago/Sources/Domain/UseCase/ObserveGlobalStateUseCase.swift
+++ b/Damago/Damago/Sources/Domain/UseCase/ObserveGlobalStateUseCase.swift
@@ -86,6 +86,7 @@ final class ObserveGlobalStateUseCaseImpl: ObserveGlobalStateUseCase {
                     foodCount: coupleSnapshot?.foodCount,
                     anniversaryDate: coupleSnapshot?.anniversaryDate,
                     currentQuestionID: coupleSnapshot?.currentQuestionID,
+                    damagoID: userSnapshot.damagoID,
                     damagoName: damagoSnapshot?.damagoName,
                     damagoType: damagoSnapshot?.damagoType,
                     level: damagoSnapshot?.level,

--- a/Damago/Damago/Sources/Presentation/Features/Home/HomeViewModel.swift
+++ b/Damago/Damago/Sources/Presentation/Features/Home/HomeViewModel.swift
@@ -187,6 +187,11 @@ final class HomeViewModel: ViewModel {
 
     private func bindGlobalState() {
         globalStore.globalState
+            .compactMap { $0.damagoID }
+            .sink { [weak self] in self?.damagoID = $0 }
+            .store(in: &cancellables)
+
+        globalStore.globalState
             .compactMapForUI { $0 }
             .sink { [weak self] state in
                 guard let self, let damagoType = state.damagoType, let isHungry = state.isHungry else { return }

--- a/Damago/Damago/Sources/Presentation/Shared/Store/GlobalState.swift
+++ b/Damago/Damago/Sources/Presentation/Shared/Store/GlobalState.swift
@@ -22,6 +22,7 @@ struct GlobalState: Equatable {
     let currentQuestionID: String?
 
     // MARK: - Damago Content
+    let damagoID: String?
     let damagoName: String?
     let damagoType: DamagoType?
     let level: Int?
@@ -43,6 +44,7 @@ struct GlobalState: Equatable {
         foodCount: nil,
         anniversaryDate: nil,
         currentQuestionID: nil,
+        damagoID: nil,
         damagoName: nil,
         damagoType: nil,
         level: nil,


### PR DESCRIPTION
다마고 ID변경 전파 및 Observe하도록 변경

## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)를 적어주세요. 해당 이슈가 존재하지 않으면 생략 가능합니다.-->
- resolves #252 

## 🥑 작업 요약
먹이를 주는 상호작용에도 변경된 다마고가 적용되도록 했습니다. 
<!-- 이번 PR에서 작업한 내용을 간략하게 설명해주세요.-->

## 🛠️ 작업 내용
- GlobalState에 다마고id 필드를 추가하여 변경된 id를 전파하도록 했습니다. 
- ObserveUseCase에서도 스냅샷의 다마고id를 GlobalState에 포함하도록 했습니다. 
- HomeViewModel에서도 다마고id 변경을 감지하고 즉시 반영하도록 리스너를 추가했습니다. 
- 
<!-- 어떻게 보다는 '왜' 이렇게 수정했는지, 의도를 중심으로 작성해주세요.
- 개발 과정에서 발생한 문제와 해결 방법, 대안 등을 정리하면 좋습니다.-->

## 📸 스크린샷 (UI 변경 시)
<!-- UI 변경 사항이 있다면 필수입니다. -->
<img src="https://github.com/user-attachments/assets/3b692c0a-5589-4fcd-bb87-d25387af7d8b" width="300" alt=""> 

## 🧪 테스트 방법
<!-- 리뷰어가 변경 사항을 확인할 수 있는 방법을 서술합니다. -->
- 다마고를 변경해가며 밥을 주어 확인해볼 수 있습니다. 

## 💬 리뷰 요구사항 (Optional)

## ✅ 체크리스트
- [x] 빌드 및 실행 테스트를 완료했나요?
- [x] 불필요한 주석 및 Print 문을 제거했나요?
- [x] 코딩 컨벤션을 준수했나요?
