### PR TITLE
[#230] Presentation / Core 계층 Repository 의존성 제거

### DIFF
--- a/Damago/Damago/Sources/Application/DI/UseCaseAssembly.swift
+++ b/Damago/Damago/Sources/Application/DI/UseCaseAssembly.swift
@@ -95,5 +95,29 @@ final class UseCaseAssembly: Assembly {
         container.register(AdjustCoinAmountUseCase.self) {
             AdjustCoinAmountUseCaseImpl(userRepository: container.resolve(UserRepositoryProtocol.self))
         }
+        
+        container.register(SaveLiveActivityTokenUseCase.self) {
+            SaveLiveActivityTokenUseCaseImpl(repository: container.resolve(PushRepositoryProtocol.self))
+        }
+        
+        container.register(ObserveDamagoSnapshotUseCase.self) {
+            ObserveDamagoSnapshotUseCaseImpl(repository: container.resolve(DamagoRepositoryProtocol.self))
+        }
+        
+        container.register(GetPokeShortcutsUseCase.self) {
+            GetPokeShortcutsUseCaseImpl(repository: container.resolve(PokeShortcutRepositoryProtocol.self))
+        }
+        
+        container.register(UpdatePokeShortcutUseCase.self) {
+            UpdatePokeShortcutUseCaseImpl(repository: container.resolve(PokeShortcutRepositoryProtocol.self))
+        }
+        
+        container.register(FeedDamagoUseCase.self) {
+            FeedDamagoUseCaseImpl(repository: container.resolve(DamagoRepositoryProtocol.self))
+        }
+        
+        container.register(PokeDamagoUseCase.self) {
+            PokeDamagoUseCaseImpl(repository: container.resolve(PushRepositoryProtocol.self))
+        }
     }
 }

--- a/Damago/Damago/Sources/Application/SceneDelegate.swift
+++ b/Damago/Damago/Sources/Application/SceneDelegate.swift
@@ -25,12 +25,12 @@ final class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         willConnectTo session: UISceneSession,
         options connectionOptions: UIScene.ConnectionOptions
     ) {
-        let userRepository = AppDIContainer.shared.resolve(UserRepositoryProtocol.self)
-        let pushRepository = AppDIContainer.shared.resolve(PushRepositoryProtocol.self)
+        let fetchUserInfoUseCase = AppDIContainer.shared.resolve(FetchUserInfoUseCase.self)
+        let saveLiveActivityTokenUseCase = AppDIContainer.shared.resolve(SaveLiveActivityTokenUseCase.self)
         let globalStore = AppDIContainer.shared.resolve(GlobalStoreProtocol.self)
         LiveActivityManager.shared.configure(
-            userRepository: userRepository,
-            pushRepository: pushRepository,
+            fetchUserInfoUseCase: fetchUserInfoUseCase,
+            saveLiveActivityTokenUseCase: saveLiveActivityTokenUseCase,
             globalStore: globalStore
         )
 
@@ -138,11 +138,11 @@ final class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             let tabBarController = TabBarViewController()
             window?.rootViewController = tabBarController
         } else {
-            let userRepository = AppDIContainer.shared.resolve(UserRepositoryProtocol.self)
+            let fetchUserInfoUseCase = AppDIContainer.shared.resolve(FetchUserInfoUseCase.self)
             let updateUserUseCase = AppDIContainer.shared.resolve(UpdateUserUseCase.self)
             let vm = ProfileSettingViewModel(
                 updateUserUseCase: updateUserUseCase,
-                userRepository: userRepository
+                fetchUserInfoUseCase: fetchUserInfoUseCase
             )
             let vc = ProfileSettingViewController(viewModel: vm)
             let navigationController = UINavigationController(rootViewController: vc)

--- a/Damago/Damago/Sources/Domain/UseCase/FeedDamagoUseCase.swift
+++ b/Damago/Damago/Sources/Domain/UseCase/FeedDamagoUseCase.swift
@@ -1,0 +1,24 @@
+//
+//  FeedDamagoUseCase.swift
+//  Damago
+//
+//  Created by 박현수 on 2/3/26.
+//
+
+import Foundation
+
+protocol FeedDamagoUseCase {
+    func execute(damagoID: String) async throws -> Bool
+}
+
+final class FeedDamagoUseCaseImpl: FeedDamagoUseCase {
+    private let repository: DamagoRepositoryProtocol
+
+    init(repository: DamagoRepositoryProtocol) {
+        self.repository = repository
+    }
+
+    func execute(damagoID: String) async throws -> Bool {
+        try await repository.feed(damagoID: damagoID)
+    }
+}

--- a/Damago/Damago/Sources/Domain/UseCase/GetPokeShortcutsUseCase.swift
+++ b/Damago/Damago/Sources/Domain/UseCase/GetPokeShortcutsUseCase.swift
@@ -1,0 +1,24 @@
+//
+//  GetPokeShortcutsUseCase.swift
+//  Damago
+//
+//  Created by 박현수 on 2/3/26.
+//
+
+import Foundation
+
+protocol GetPokeShortcutsUseCase {
+    func execute() -> [PokeShortcut]
+}
+
+final class GetPokeShortcutsUseCaseImpl: GetPokeShortcutsUseCase {
+    private let repository: PokeShortcutRepositoryProtocol
+
+    init(repository: PokeShortcutRepositoryProtocol) {
+        self.repository = repository
+    }
+
+    func execute() -> [PokeShortcut] {
+        repository.shortcuts
+    }
+}

--- a/Damago/Damago/Sources/Domain/UseCase/ObserveDamagoSnapshotUseCase.swift
+++ b/Damago/Damago/Sources/Domain/UseCase/ObserveDamagoSnapshotUseCase.swift
@@ -1,0 +1,24 @@
+//
+//  ObserveDamagoSnapshotUseCase.swift
+//  Damago
+//
+//  Created by 박현수 on 2/3/26.
+//
+
+import Combine
+
+protocol ObserveDamagoSnapshotUseCase {
+    func execute(damagoID: String) -> AnyPublisher<Result<DamagoSnapshotDTO, Error>, Never>
+}
+
+final class ObserveDamagoSnapshotUseCaseImpl: ObserveDamagoSnapshotUseCase {
+    private let repository: DamagoRepositoryProtocol
+
+    init(repository: DamagoRepositoryProtocol) {
+        self.repository = repository
+    }
+
+    func execute(damagoID: String) -> AnyPublisher<Result<DamagoSnapshotDTO, Error>, Never> {
+        repository.observeDamagoSnapshot(damagoID: damagoID)
+    }
+}

--- a/Damago/Damago/Sources/Domain/UseCase/PokeDamagoUseCase.swift
+++ b/Damago/Damago/Sources/Domain/UseCase/PokeDamagoUseCase.swift
@@ -1,0 +1,24 @@
+//
+//  PokeDamagoUseCase.swift
+//  Damago
+//
+//  Created by 박현수 on 2/3/26.
+//
+
+import Foundation
+
+protocol PokeDamagoUseCase {
+    func execute(message: String) async throws -> Bool
+}
+
+final class PokeDamagoUseCaseImpl: PokeDamagoUseCase {
+    private let repository: PushRepositoryProtocol
+
+    init(repository: PushRepositoryProtocol) {
+        self.repository = repository
+    }
+
+    func execute(message: String) async throws -> Bool {
+        try await repository.poke(message: message)
+    }
+}

--- a/Damago/Damago/Sources/Domain/UseCase/SaveLiveActivityTokenUseCase.swift
+++ b/Damago/Damago/Sources/Domain/UseCase/SaveLiveActivityTokenUseCase.swift
@@ -1,0 +1,24 @@
+//
+//  SaveLiveActivityTokenUseCase.swift
+//  Damago
+//
+//  Created by 박현수 on 2/3/26.
+//
+
+import Foundation
+
+protocol SaveLiveActivityTokenUseCase {
+    func execute(startToken: String?, updateToken: String?) async throws -> Bool
+}
+
+final class SaveLiveActivityTokenUseCaseImpl: SaveLiveActivityTokenUseCase {
+    private let repository: PushRepositoryProtocol
+
+    init(repository: PushRepositoryProtocol) {
+        self.repository = repository
+    }
+
+    func execute(startToken: String?, updateToken: String?) async throws -> Bool {
+        try await repository.saveLiveActivityToken(startToken: startToken, updateToken: updateToken)
+    }
+}

--- a/Damago/Damago/Sources/Domain/UseCase/UpdatePokeShortcutUseCase.swift
+++ b/Damago/Damago/Sources/Domain/UseCase/UpdatePokeShortcutUseCase.swift
@@ -1,0 +1,24 @@
+//
+//  UpdatePokeShortcutUseCase.swift
+//  Damago
+//
+//  Created by 박현수 on 2/3/26.
+//
+
+import Foundation
+
+protocol UpdatePokeShortcutUseCase {
+    func execute(at index: Int, shortcut: PokeShortcut)
+}
+
+final class UpdatePokeShortcutUseCaseImpl: UpdatePokeShortcutUseCase {
+    private let repository: PokeShortcutRepositoryProtocol
+
+    init(repository: PokeShortcutRepositoryProtocol) {
+        self.repository = repository
+    }
+
+    func execute(at index: Int, shortcut: PokeShortcut) {
+        repository.updateShortcut(at: index, shortcut: shortcut)
+    }
+}

--- a/Damago/Damago/Sources/Presentation/Features/Connection/ConnectionViewController.swift
+++ b/Damago/Damago/Sources/Presentation/Features/Connection/ConnectionViewController.swift
@@ -100,11 +100,11 @@ final class ConnectionViewController: UIViewController {
                 case let .activity(url):
                     presentActivity(with: url)
                 case .editProfile:
-                    let userRepository = AppDIContainer.shared.resolve(UserRepositoryProtocol.self)
+                    let fetchUserInfoUseCase = AppDIContainer.shared.resolve(FetchUserInfoUseCase.self)
                     let updateUserUseCase = AppDIContainer.shared.resolve(UpdateUserUseCase.self)
                     let vm = ProfileSettingViewModel(
                         updateUserUseCase: updateUserUseCase,
-                        userRepository: userRepository
+                        fetchUserInfoUseCase: fetchUserInfoUseCase
                     )
                     let vc = ProfileSettingViewController(viewModel: vm)
                     let navigationController = UINavigationController(rootViewController: vc)

--- a/Damago/Damago/Sources/Presentation/Features/Home/HomeViewController.swift
+++ b/Damago/Damago/Sources/Presentation/Features/Home/HomeViewController.swift
@@ -148,8 +148,12 @@ final class HomeViewController: UIViewController {
     }
     
     private func showPokeMessagePopup() {
-        let shortcutRepository = AppDIContainer.shared.resolve(PokeShortcutRepositoryProtocol.self)
-        let popupViewController = PokePopupViewController(shortcutRepository: shortcutRepository)
+        let getPokeShortcutsUseCase = AppDIContainer.shared.resolve(GetPokeShortcutsUseCase.self)
+        let updatePokeShortcutUseCase = AppDIContainer.shared.resolve(UpdatePokeShortcutUseCase.self)
+        let popupViewController = PokePopupViewController(
+            getPokeShortcutsUseCase: getPokeShortcutsUseCase,
+            updatePokeShortcutUseCase: updatePokeShortcutUseCase
+        )
         popupViewController.modalPresentationStyle = .overFullScreen
         popupViewController.modalTransitionStyle = .crossDissolve
         

--- a/Damago/Damago/Sources/Presentation/Features/Home/HomeViewModel.swift
+++ b/Damago/Damago/Sources/Presentation/Features/Home/HomeViewModel.swift
@@ -50,22 +50,22 @@ final class HomeViewModel: ViewModel {
     private var damagoID: String?
 
     private let globalStore: GlobalStoreProtocol
-    private let userRepository: UserRepositoryProtocol
-    private let damagoRepository: DamagoRepositoryProtocol
-    private let pushRepository: PushRepositoryProtocol
+    private let fetchUserInfoUseCase: FetchUserInfoUseCase
+    private let feedDamagoUseCase: FeedDamagoUseCase
+    private let pokeDamagoUseCase: PokeDamagoUseCase
     private let updateUserUseCase: UpdateUserUseCase
     
     init(
         globalStore: GlobalStoreProtocol,
-        userRepository: UserRepositoryProtocol,
-        damagoRepository: DamagoRepositoryProtocol,
-        pushRepository: PushRepositoryProtocol,
+        fetchUserInfoUseCase: FetchUserInfoUseCase,
+        feedDamagoUseCase: FeedDamagoUseCase,
+        pokeDamagoUseCase: PokeDamagoUseCase,
         updateUserUseCase: UpdateUserUseCase
     ) {
         self.globalStore = globalStore
-        self.userRepository = userRepository
-        self.damagoRepository = damagoRepository
-        self.pushRepository = pushRepository
+        self.fetchUserInfoUseCase = fetchUserInfoUseCase
+        self.feedDamagoUseCase = feedDamagoUseCase
+        self.pokeDamagoUseCase = pokeDamagoUseCase
         self.updateUserUseCase = updateUserUseCase
     }
 
@@ -107,7 +107,7 @@ final class HomeViewModel: ViewModel {
                 state.isLoading = false
             }
             do {
-                let userInfo = try await userRepository.getUserInfo()
+                let userInfo = try await fetchUserInfoUseCase.execute()
 
                 self.damagoID = userInfo.damagoID
                 state.totalCoin = userInfo.totalCoin
@@ -133,7 +133,7 @@ final class HomeViewModel: ViewModel {
         Task {
             do {
                 state.isFeeding = true
-                let success = try await damagoRepository.feed(damagoID: damagoID)
+                let success = try await feedDamagoUseCase.execute(damagoID: damagoID)
                 if success {
                     state.lastFedAt = Date()
                     LiveActivityManager.shared.synchronizeActivity()
@@ -150,7 +150,7 @@ final class HomeViewModel: ViewModel {
     private func pokeDamago(with message: String) {
         Task {
             do {
-                _ = try await pushRepository.poke(message: message)
+                _ = try await pokeDamagoUseCase.execute(message: message)
                 print("Poke sent with message: \(message)")
             } catch {
                 print("Error poking damago: \(error)")

--- a/Damago/Damago/Sources/Presentation/Features/Home/PokePopup/PokePopupViewController.swift
+++ b/Damago/Damago/Sources/Presentation/Features/Home/PokePopup/PokePopupViewController.swift
@@ -19,8 +19,14 @@ final class PokePopupViewController: UIViewController {
     var onMessageSelected: ((String) -> Void)?
     var onCancel: (() -> Void)?
     
-    init(shortcutRepository: PokeShortcutRepositoryProtocol) {
-        self.viewModel = PokePopupViewModel(shortcutRepository: shortcutRepository)
+    init(
+        getPokeShortcutsUseCase: GetPokeShortcutsUseCase,
+        updatePokeShortcutUseCase: UpdatePokeShortcutUseCase
+    ) {
+        self.viewModel = PokePopupViewModel(
+            getPokeShortcutsUseCase: getPokeShortcutsUseCase,
+            updatePokeShortcutUseCase: updatePokeShortcutUseCase
+        )
         super.init(nibName: nil, bundle: nil)
     }
     

--- a/Damago/Damago/Sources/Presentation/Features/Home/PokePopup/PokePopupViewModel.swift
+++ b/Damago/Damago/Sources/Presentation/Features/Home/PokePopup/PokePopupViewModel.swift
@@ -42,15 +42,20 @@ final class PokePopupViewModel: ViewModel {
     
     @Published private var state = State()
     private var cancellables = Set<AnyCancellable>()
-    private let shortcutRepository: PokeShortcutRepositoryProtocol
+    private let getPokeShortcutsUseCase: GetPokeShortcutsUseCase
+    private let updatePokeShortcutUseCase: UpdatePokeShortcutUseCase
     private var originalShortcuts: [PokeShortcut] = [] // 편집 모드 진입 시 원본 데이터 저장
     
     var onMessageSelected: ((String) -> Void)?
     var onCancel: (() -> Void)?
     var onRequestCancelConfirmation: ((@escaping () -> Void) -> Void)?
     
-    init(shortcutRepository: PokeShortcutRepositoryProtocol) {
-        self.shortcutRepository = shortcutRepository
+    init(
+        getPokeShortcutsUseCase: GetPokeShortcutsUseCase,
+        updatePokeShortcutUseCase: UpdatePokeShortcutUseCase
+    ) {
+        self.getPokeShortcutsUseCase = getPokeShortcutsUseCase
+        self.updatePokeShortcutUseCase = updatePokeShortcutUseCase
     }
     
     func transform(_ input: Input) -> AnyPublisher<State, Never> {
@@ -124,7 +129,7 @@ final class PokePopupViewModel: ViewModel {
     }
     
     private func loadShortcuts() {
-        updateState(shortcuts: shortcutRepository.shortcuts)
+        updateState(shortcuts: getPokeShortcutsUseCase.execute())
     }
     
     private func handleSend() {
@@ -206,7 +211,7 @@ final class PokePopupViewModel: ViewModel {
     private func saveShortcuts() {
         // 각 shortcut을 개별적으로 업데이트
         state.shortcuts.enumerated().forEach { index, shortcut in
-            shortcutRepository.updateShortcut(at: index, shortcut: shortcut)
+            updatePokeShortcutUseCase.execute(at: index, shortcut: shortcut)
         }
         updateState(isEditing: false)
     }

--- a/Damago/Damago/Sources/Presentation/Features/Interaction/InteractionViewModel.swift
+++ b/Damago/Damago/Sources/Presentation/Features/Interaction/InteractionViewModel.swift
@@ -32,7 +32,6 @@ final class InteractionViewModel: ViewModel {
 
     private let fetchDailyQuestionUseCase: FetchDailyQuestionUseCase
     private let observeDailyQuestionAnswerUseCase: ObserveDailyQuestionAnswerUseCase
-    private let userRepository: UserRepositoryProtocol
     private let globalStore: GlobalStoreProtocol
 
     private let fetchBalanceGameUseCase: FetchBalanceGameUseCase
@@ -65,7 +64,6 @@ final class InteractionViewModel: ViewModel {
         fetchBalanceGameUseCase: FetchBalanceGameUseCase,
         observeBalanceGameAnswerUseCase: ObserveBalanceGameAnswerUseCase,
         submitBalanceGameChoiceUseCase: SubmitBalanceGameChoiceUseCase,
-        userRepository: UserRepositoryProtocol,
         globalStore: GlobalStoreProtocol
     ) {
         self.fetchDailyQuestionUseCase = fetchDailyQuestionUseCase
@@ -73,7 +71,6 @@ final class InteractionViewModel: ViewModel {
         self.fetchBalanceGameUseCase = fetchBalanceGameUseCase
         self.observeBalanceGameAnswerUseCase = observeBalanceGameAnswerUseCase
         self.submitBalanceGameChoiceUseCase = submitBalanceGameChoiceUseCase
-        self.userRepository = userRepository
         self.globalStore = globalStore
     }
 

--- a/Damago/Damago/Sources/Presentation/Features/Onboarding/DamagoSetup/DamagoSetupViewModel.swift
+++ b/Damago/Damago/Sources/Presentation/Features/Onboarding/DamagoSetup/DamagoSetupViewModel.swift
@@ -37,18 +37,18 @@ final class DamagoSetupViewModel: ViewModel {
     
     private let updateUserUseCase: UpdateUserUseCase
     private let fetchUserInfoUseCase: FetchUserInfoUseCase
-    private let damagoRepository: DamagoRepositoryProtocol
+    private let observeDamagoSnapshotUseCase: ObserveDamagoSnapshotUseCase
     private let globalStore: GlobalStoreProtocol
     
     init(
         updateUserUseCase: UpdateUserUseCase,
         fetchUserInfoUseCase: FetchUserInfoUseCase,
-        damagoRepository: DamagoRepositoryProtocol,
+        observeDamagoSnapshotUseCase: ObserveDamagoSnapshotUseCase,
         globalStore: GlobalStoreProtocol
     ) {
         self.updateUserUseCase = updateUserUseCase
         self.fetchUserInfoUseCase = fetchUserInfoUseCase
-        self.damagoRepository = damagoRepository
+        self.observeDamagoSnapshotUseCase = observeDamagoSnapshotUseCase
         self.globalStore = globalStore
     }
     
@@ -91,7 +91,7 @@ final class DamagoSetupViewModel: ViewModel {
             return Empty().eraseToAnyPublisher()
         }
         let damagoID = "\(coupleID)_\(damagoType.rawValue)"
-        return damagoRepository.observeDamagoSnapshot(damagoID: damagoID)
+        return observeDamagoSnapshotUseCase.execute(damagoID: damagoID)
             .compactMap { try? $0.get().damagoName }
             .removeDuplicates()
             .eraseToAnyPublisher()

--- a/Damago/Damago/Sources/Presentation/Features/Onboarding/ProfileSetting/ProfileSettingViewController.swift
+++ b/Damago/Damago/Sources/Presentation/Features/Onboarding/ProfileSetting/ProfileSettingViewController.swift
@@ -116,12 +116,12 @@ final class ProfileSettingViewController: UIViewController {
     private func navigateToDamagoSetup() {
         let updateUserUseCase = AppDIContainer.shared.resolve(UpdateUserUseCase.self)
         let fetchUserInfoUseCase = AppDIContainer.shared.resolve(FetchUserInfoUseCase.self)
-        let damagoRepository = AppDIContainer.shared.resolve(DamagoRepositoryProtocol.self)
+        let observeDamagoSnapshotUseCase = AppDIContainer.shared.resolve(ObserveDamagoSnapshotUseCase.self)
         let globalStore = AppDIContainer.shared.resolve(GlobalStoreProtocol.self)
         let vm = DamagoSetupViewModel(
             updateUserUseCase: updateUserUseCase,
             fetchUserInfoUseCase: fetchUserInfoUseCase,
-            damagoRepository: damagoRepository,
+            observeDamagoSnapshotUseCase: observeDamagoSnapshotUseCase,
             globalStore: globalStore
         )
         let vc = DamagoSetupViewController(viewModel: vm)

--- a/Damago/Damago/Sources/Presentation/Features/Onboarding/ProfileSetting/ProfileSettingViewModel.swift
+++ b/Damago/Damago/Sources/Presentation/Features/Onboarding/ProfileSetting/ProfileSettingViewModel.swift
@@ -36,14 +36,14 @@ final class ProfileSettingViewModel: ViewModel {
     private var cancellables = Set<AnyCancellable>()
     
     private let updateUserUseCase: UpdateUserUseCase
-    private let userRepository: UserRepositoryProtocol
+    private let fetchUserInfoUseCase: FetchUserInfoUseCase
     
     init(
         updateUserUseCase: UpdateUserUseCase,
-        userRepository: UserRepositoryProtocol
+        fetchUserInfoUseCase: FetchUserInfoUseCase
     ) {
         self.updateUserUseCase = updateUserUseCase
-        self.userRepository = userRepository
+        self.fetchUserInfoUseCase = fetchUserInfoUseCase
     }
     
     func transform(_ input: Input) -> AnyPublisher<State, Never> {
@@ -84,7 +84,7 @@ final class ProfileSettingViewModel: ViewModel {
                 )
                 
                 // 최신 정보를 직접 조회하여 파트너가 펫을 결정했는지 확인
-                let userInfo = try await userRepository.getUserInfo()
+                let userInfo = try await fetchUserInfoUseCase.execute()
                 
                 if userInfo.damagoID != nil {
                     state.route = Pulse(.partnerAlreadySelected)

--- a/Damago/Damago/Sources/Presentation/Features/TabBar/TabBarViewController.swift
+++ b/Damago/Damago/Sources/Presentation/Features/TabBar/TabBarViewController.swift
@@ -114,16 +114,16 @@ final class TabBarViewController: UITabBarController {
             return CollectionViewController(viewModel: viewModel)
         case .home:
             let globalStore = AppDIContainer.shared.resolve(GlobalStoreProtocol.self)
-            let userRepository = AppDIContainer.shared.resolve(UserRepositoryProtocol.self)
-            let damagoRepository = AppDIContainer.shared.resolve(DamagoRepositoryProtocol.self)
-            let pushRepository = AppDIContainer.shared.resolve(PushRepositoryProtocol.self)
+            let fetchUserInfoUseCase = AppDIContainer.shared.resolve(FetchUserInfoUseCase.self)
+            let feedDamagoUseCase = AppDIContainer.shared.resolve(FeedDamagoUseCase.self)
+            let pokeDamagoUseCase = AppDIContainer.shared.resolve(PokeDamagoUseCase.self)
             let updateUserUseCase = AppDIContainer.shared.resolve(UpdateUserUseCase.self)
 
             let vm = HomeViewModel(
                 globalStore: globalStore,
-                userRepository: userRepository,
-                damagoRepository: damagoRepository,
-                pushRepository: pushRepository,
+                fetchUserInfoUseCase: fetchUserInfoUseCase,
+                feedDamagoUseCase: feedDamagoUseCase,
+                pokeDamagoUseCase: pokeDamagoUseCase,
                 updateUserUseCase: updateUserUseCase
             )
             let vc = HomeViewController(viewModel: vm)
@@ -136,7 +136,6 @@ final class TabBarViewController: UITabBarController {
             let fetchBalanceGameUseCase = AppDIContainer.shared.resolve(FetchBalanceGameUseCase.self)
             let observeBalanceGameAnswerUseCase = AppDIContainer.shared.resolve(ObserveBalanceGameAnswerUseCase.self)
             let submitBalanceGameChoiceUseCase = AppDIContainer.shared.resolve(SubmitBalanceGameChoiceUseCase.self)
-            let userRepository = AppDIContainer.shared.resolve(UserRepositoryProtocol.self)
             let globalStore = AppDIContainer.shared.resolve(GlobalStoreProtocol.self)
 
             let vm = InteractionViewModel(
@@ -145,7 +144,6 @@ final class TabBarViewController: UITabBarController {
                 fetchBalanceGameUseCase: fetchBalanceGameUseCase,
                 observeBalanceGameAnswerUseCase: observeBalanceGameAnswerUseCase,
                 submitBalanceGameChoiceUseCase: submitBalanceGameChoiceUseCase,
-                userRepository: userRepository,
                 globalStore: globalStore
             )
             let vc = InteractionViewController(viewModel: vm)


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)를 적어주세요. 해당 이슈가 존재하지 않으면 생략 가능합니다.-->
- resolves #230

## 🥑 작업 요약
Presentation 및 Core 계층에서 직접적으로 Repository를 의존하던 코드를 리팩토링하여, UseCase를 통해 데이터에 접근하도록 변경했습니다.

## 🛠️ 작업 내용
- **UseCase 신규 생성 및 등록**
  - 기존 Repository 메서드를 캡슐화하는 6개의 UseCase를 생성하고 `UseCaseAssembly`에 등록했습니다.
    - `FeedDamagoUseCase`
    - `GetPokeShortcutsUseCase`
    - `ObserveDamagoSnapshotUseCase`
    - `PokeDamagoUseCase`
    - `SaveLiveActivityTokenUseCase`
    - `UpdatePokeShortcutUseCase`

- **Repository 의존성 제거 및 UseCase 적용**
  - **Core Layer**: `LiveActivityManager`가 `UserRepository`, `PushRepository` 대신 `FetchUserInfoUseCase`, `SaveLiveActivityTokenUseCase`를 사용하도록 수정했습니다.
  - **Presentation Layer**: `HomeViewModel`, `PokePopupViewModel`, `DamagoSetupViewModel`, `ProfileSettingViewModel` 등에서 Repository 의존성을 제거하고, 각 기능에 맞는 UseCase를 주입받도록 변경했습니다.
  - **Dependency Injection**: `SceneDelegate`, `TabBarViewController`, 각 ViewController에서 ViewModel 및 Manager 생성 시 UseCase를 주입하도록 DI 코드를 업데이트했습니다.

- **Clean Architecture 원칙 준수**
  - Presentation 계층이 Data 계층(Repository)을 직접 알지 못하게 하고, Domain 계층(UseCase)을 거치도록 강제함으로써 계층 간 결합도를 낮추고 아키텍처 일관성을 확보했습니다.

## ✅ 체크리스트
- [x] 빌드 및 실행 테스트를 완료했나요?
- [x] 불필요한 주석 및 Print 문을 제거했나요?
- [x] 코딩 컨벤션을 준수했나요?
