### PR TITLE
[#250] 커플 상호작용 코드 리팩터링

### DIFF
--- a/Damago/Damago/Sources/Data/Repository/BalanceGameRepository.swift
+++ b/Damago/Damago/Sources/Data/Repository/BalanceGameRepository.swift
@@ -10,7 +10,7 @@ import DamagoNetwork
 import Foundation
 import OSLog
 
-final class BalanceGameRepository: BalanceGameRepositoryProtocol {
+final class BalanceGameRepository: BalanceGameRepositoryProtocol, DataSyncStrategy {
     private let networkProvider: NetworkProvider
     private let tokenProvider: TokenProvider
     private let firestoreService: FirestoreService
@@ -174,7 +174,7 @@ final class BalanceGameRepository: BalanceGameRepositoryProtocol {
             SharedLogger.interaction.error("Local save failed: \(error)")
         }
     }
-
+    
     @MainActor
     private func updateLocalChoice(gameID: String, response: FirestoreBalanceGameAnswerDTO) async {
         do {

--- a/Damago/Damago/Sources/Data/Repository/BalanceGameRepository.swift
+++ b/Damago/Damago/Sources/Data/Repository/BalanceGameRepository.swift
@@ -188,6 +188,19 @@ final class BalanceGameRepository: BalanceGameRepositoryProtocol {
             SharedLogger.interaction.error("Local update failed: \(error)")
         }
     }
+    
+    private func mapToDTO(entity: BalanceGameEntity) -> BalanceGameDTO {
+        BalanceGameDTO(
+            gameID: entity.gameID,
+            questionContent: entity.questionContent,
+            option1: entity.option1,
+            option2: entity.option2,
+            myChoice: entity.isUser1 ? entity.user1Choice : entity.user2Choice,
+            opponentChoice: entity.isUser1 ? entity.user2Choice : entity.user1Choice,
+            isUser1: entity.isUser1,
+            lastAnsweredAt: entity.lastAnsweredAt
+        )
+    }
 }
 
 private struct FirestoreBalanceGameAnswerDTO: Decodable {

--- a/Damago/Damago/Sources/Data/Repository/DailyQuestionRepository.swift
+++ b/Damago/Damago/Sources/Data/Repository/DailyQuestionRepository.swift
@@ -181,6 +181,18 @@ final class DailyQuestionRepository: DailyQuestionRepositoryProtocol {
             SharedLogger.interaction.error("Local update failed: \(error)")
         }
     }
+
+    private func mapToDTO(entity: DailyQuestionEntity) -> DailyQuestionDTO {
+        DailyQuestionDTO(
+            questionID: entity.questionID,
+            questionContent: entity.questionContent,
+            user1Answer: entity.user1Answer,
+            user2Answer: entity.user2Answer,
+            bothAnswered: entity.bothAnswered,
+            lastAnsweredAt: entity.lastAnsweredAt,
+            isUser1: entity.isUser1
+        )
+    }
 }
 
 private struct FirestoreAnswerDTO: Decodable {

--- a/Damago/Damago/Sources/Data/Repository/DailyQuestionRepository.swift
+++ b/Damago/Damago/Sources/Data/Repository/DailyQuestionRepository.swift
@@ -9,12 +9,12 @@ import Combine
 import DamagoNetwork
 import OSLog
 
-final class DailyQuestionRepository: DailyQuestionRepositoryProtocol {
+final class DailyQuestionRepository: DailyQuestionRepositoryProtocol, DataSyncStrategy {
     private let networkProvider: NetworkProvider
     private let tokenProvider: TokenProvider
     private let firestoreService: FirestoreService
     private let localDataSource: DailyQuestionLocalDataSourceProtocol
-    
+
     init(
         networkProvider: NetworkProvider,
         tokenProvider: TokenProvider,
@@ -166,7 +166,7 @@ final class DailyQuestionRepository: DailyQuestionRepositoryProtocol {
             SharedLogger.interaction.error("Local save failed: \(error)")
         }
     }
-    
+
     @MainActor
     private func updateLocalAnswer(questionID: String, response: FirestoreAnswerDTO) async {
         do {

--- a/Damago/Damago/Sources/Data/Repository/DataSyncStrategy.swift
+++ b/Damago/Damago/Sources/Data/Repository/DataSyncStrategy.swift
@@ -1,0 +1,48 @@
+//
+//  DataSyncStrategy.swift
+//  Damago
+//
+//  Created by Eden Landelyse on 2/3/26.
+//
+
+import Foundation
+
+protocol DataSyncStrategy {
+    func createFetchStream<T>(
+        fetchLocal: @escaping () async throws -> T?,
+        checkIsUpToDate: @escaping (T) -> Bool,
+        fetchNetwork: @escaping () async throws -> T,
+        saveToLocal: @escaping (T) async -> Void,
+        onNetworkError: @escaping (Error) -> Void
+    ) -> AsyncStream<T>
+}
+
+extension DataSyncStrategy {
+    func createFetchStream<T>(
+        fetchLocal: @escaping () async throws -> T?,
+        checkIsUpToDate: @escaping (T) -> Bool,
+        fetchNetwork: @escaping () async throws -> T,
+        saveToLocal: @escaping (T) async -> Void,
+        onNetworkError: @escaping (Error) -> Void
+    ) -> AsyncStream<T> {
+        AsyncStream { continuation in
+            Task {
+                // 로컬 데이터 조회
+                if let localData = try? await fetchLocal(), checkIsUpToDate(localData) {
+                    continuation.yield(localData)
+                }
+
+                // 네트워크 데이터 조회
+                do {
+                    let remoteData = try await fetchNetwork()
+                    await saveToLocal(remoteData)
+                    continuation.yield(remoteData)
+                } catch {
+                    onNetworkError(error)
+                }
+
+                continuation.finish()
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)를 적어주세요. 해당 이슈가 존재하지 않으면 생략 가능합니다.-->
- resolves #250 

## 🥑 작업 요약
커플 상호작용 시 동작하는 `DataSource`와 `Repository`를 분석하고 가능한 부분을 리팩터링했습니다.
<!-- 이번 PR에서 작업한 내용을 간략하게 설명해주세요.-->

## 🛠️ 작업 내용
상세한 내용은 [위키 문서](https://github.com/boostcampwm2025/ios02-damago/wiki/커플-상호작용-리팩터링-과정)에 정리해두었습니다.  
`DataSource`의 경우 `#Predicate` 매크로 추상화에 대한 어려움과 Entity나 파라미터 타입, 동작 흐름의 차이(draft 저장 등)이 꽤 구체적으로 다른 상태이며 클로저를 사용하는 방식으로 개선하기에는 현재 코드가 훨씬 간결하여 억지로 추상화하기보다 유지하는 편이 낫다고 판단하였습니다. 

`Repository`의 경우에도 DTO나 파라미터 타입에서 차이가 존재했지만 두 상호작용의 동작 흐름이 모두 동일함을 확인했습니다.   
이 흐름만을 추상화하여 프로토콜 확장 형태로 제공하면 실수로 에러 처리나 롤백 처리가 누락되는 경우를 줄일 수 있을 것이라 판단했습니다.  

따라서 프로토콜에는 각 메서드에 대해 다음의 흐름을 담은 오케스트라 메서드를 작성해두고, 구체적인 로직은 `Repository`에서 작성하여 전달하도록 했습니다. 
- fetch: 캐시 확인 → 방출 → 네트워크 호출 → 로컬 저장 → 최신 정보 방출
- submit: 로컬 백업 → 낙관적 UI 업데이트 → 네트워크 호출 → 실패 시 롤백
- observe: firestore 구독 → 변경 감지 후 로컬 업데이트 → DTO에 매핑하여 방출

`fetch`의 as-is와 to-be를 비교해보면 다음과 같습니다.

```swift
AsyncStream { continuation in
	Task {
		// 1. 로컬 데이터 조회 및 즉시 방출 (오늘 데이터인 경우만)
		if let entity = try? await localDataSource.fetchLatestGame(),
		   let lastUpdated = entity.lastUpdated,
		   Calendar.current.isDateInToday(lastUpdated) {
			
			let dto = BalanceGameDTO(
				gameID: entity.gameID,
				questionContent: entity.questionContent,
				option1: entity.option1,
				option2: entity.option2,
				myChoice: entity.isUser1 ? entity.user1Choice : entity.user2Choice,
				opponentChoice: entity.isUser1 ? entity.user2Choice : entity.user1Choice,
				isUser1: entity.isUser1,
				lastAnsweredAt: entity.lastAnsweredAt
			)
			continuation.yield(dto)
		}

		// 2. 네트워크 데이터 조회 및 방출
		do {
			let token = try await tokenProvider.idToken()
			let dto: BalanceGameDTO = try await networkProvider.request(
				BalanceGameAPI.fetch(accessToken: token)
			)
			await saveToLocalGame(dto: dto)
			continuation.yield(dto)
		} catch {
			SharedLogger.interaction.error("Balance Game 네트워크 조회 실패: \(error.localizedDescription)")
		}

		continuation.finish()
	}
}
```

```swift
createFetchStream(
	fetchLocal: { [weak self] in
		guard let self else { return nil }
		guard let entity = try await self.localDataSource.fetchLatestQuestion() else { return nil }
		return self.mapToDTO(entity: entity)
	},
	checkIsUpToDate: { dto in
		guard let lastAnswered = dto.lastAnsweredAt else { return false }
		return Calendar.current.isDateInToday(lastAnswered)
	},
	fetchNetwork: { [weak self] in
		guard let self else { throw URLError(.unknown) }
		let token = try await self.tokenProvider.idToken()
		return try await self.networkProvider.request(DailyQuestionAPI.fetch(accessToken: token))
	},
	saveToLocal: { [weak self] dto in
		await self?.saveToLocalAnswer(dto: dto)
	},
	onNetworkError: { error in
		SharedLogger.interaction.error("Daily Question 네트워크 조회 실패: \(error.localizedDescription)")
	}
)
```
<!-- 어떻게 보다는 '왜' 이렇게 수정했는지, 의도를 중심으로 작성해주세요.
- 개발 과정에서 발생한 문제와 해결 방법, 대안 등을 정리하면 좋습니다.-->

## 🧪 테스트 방법
<!-- 리뷰어가 변경 사항을 확인할 수 있는 방법을 서술합니다. -->
- 빌드 및 직접 사용 테스트를 진행했습니다.
- 
## 💬 리뷰 요구사항 (Optional)
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
예: 메서드 XXX의 이름이 직관적인지, 리팩토링 방식이 적절한지 등 -->
- 전체적으로 어떻게 데이터를 다루고 동기화할지에 대한 전략이라고 판단되어 `DataSyncStrategy`라고 이름지었습니다. 다른 의견이 있으시면 알려주시면 감사하겠습니다.
- 현재 Repository에 대한 테스트코드가 없어 리팩터링의 전후를 안전하게 판단할 장치가 없습니다. 때문에 테스트코드 작성을 선행하고 다시 이 PR을 진행하는 것이 나을지 아니며 이번주 마무리를 위해 다른 Task를 진행하는 것이 나을지 의견 주시면 감사하겠습니다.

## ✅ 체크리스트
- [x] 빌드 및 실행 테스트를 완료했나요?
- [x] 불필요한 주석 및 Print 문을 제거했나요?
- [x] 코딩 컨벤션을 준수했나요?
