### PR TITLE
[#265] 자신과 커플 연결 후 탈퇴 시 500 에러 수정

### DIFF
--- a/DamagoFirebase/functions/services/auth_service.py
+++ b/DamagoFirebase/functions/services/auth_service.py
@@ -262,8 +262,8 @@ def withdraw_user(req: https_fn.Request) -> https_fn.Response:
         for doc in db.collection("damagos").where("coupleID", "==", couple_id).stream():
             batch.delete(doc.reference)
 
-    # 4. 파트너 정보 초기화
-    if partner_uid:
+    # 4. 파트너 정보 초기화 (본인이 아닌 경우에만)
+    if partner_uid and partner_uid != uid:
         partner_ref = db.collection("users").document(partner_uid)
         batch.update(partner_ref, {
             "coupleID": firestore.DELETE_FIELD,


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)를 적어주세요. 해당 이슈가 존재하지 않으면 생략 가능합니다.-->
- resolves #265

## 🥑 작업 요약
- 자기 자신과 커플 연결 후 탈퇴 시 발생하는 500 에러를 수정했습니다.

## 🛠️ 작업 내용
- **회원 탈퇴 시 Firestore Batch 충돌 해결**
    - 스스로와 연결되어 있는 경우, Firestore Batch 내에서 동일한 문서(본인 계정)를 삭제(`delete`)하고 동시에 수정(`update`)하려 할 때500 에러가 발생했습니다.
    - `withdraw_user` 함수에서 파트너가 본인(`uid == partner_uid`)인 경우, 파트너 정보를 업데이트하는 로직을 건너뛰도록 수정했습니다.

## ✅ 체크리스트
- [x] 빌드 및 실행 테스트를 완료했나요?
- [x] 불필요한 주석 및 Print 문을 제거했나요?
- [x] 코딩 컨벤션을 준수했나요?
