### PR TITLE
[#254] APNs 기기토큰 등록 실패 재시도 및 알럿

### DIFF
--- a/Damago/Damago/Sources/Application/AppDelegate.swift
+++ b/Damago/Damago/Sources/Application/AppDelegate.swift
@@ -16,6 +16,8 @@ import TipKit
 
 @main
 final class AppDelegate: UIResponder, UIApplicationDelegate {
+    private var apnsRetryCount = 0
+    private let maxRetryCount = 3
 
     /// 앱이 처음 실행될 때 호출되는 메소드입니다.
     /// Firebase 설정, 알림 권한 요청, Delegate 연결 등의 초기화 작업을 수행합니다.
@@ -94,6 +96,7 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
         _ application: UIApplication,
         didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data
     ) {
+        self.apnsRetryCount = 0
         SharedLogger.apns.info("✅ APNs token retrieved: \(deviceToken.map { String(format: "%02.2hhx", $0) }.joined())")
 
         // 발급받은 APNs 토큰을 Firebase Messaging에 연결합니다.
@@ -115,8 +118,38 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
         _ application: UIApplication,
         didFailToRegisterForRemoteNotificationsWithError error: any Error
     ) {
-        // TODO: - 유저 피드백 제공
-        // ex) Alert와 함께 앱 종료
+        SharedLogger.apns.error("❌ Failed to register for remote notifications with error: \(error.localizedDescription)")
+        
+        if apnsRetryCount < maxRetryCount {
+            apnsRetryCount += 1
+            let delay = apnsRetryCount * 2
+            
+            SharedLogger.apns.info("🔄 \(delay)초 후 APNs 등록 재시도합니다... (횟수: \(self.apnsRetryCount))")
+            
+            Task {
+                try? await Task.sleep(for: .seconds(delay))
+                UIApplication.shared.registerForRemoteNotifications()
+            }
+        } else {
+            SharedLogger.apns.error("⛔️ Remote notification registration 최종 실패: 재시도 횟수 초과")
+            showFinalFailureAlert(error: error)
+        }
+    }
+    
+    private func showFinalFailureAlert(error: Error) {
+        let alert = UIAlertController(
+            title: "알림 연결 실패",
+            message: "서버 연결이 불안정하여 알림을 받을 수 없습니다.\n잠시 후에 앱을 재실행해주세요.",
+            preferredStyle: .alert
+        )
+        alert.addAction(UIAlertAction(title: "확인", style: .default))
+        
+        let keyWindow = UIApplication.shared.connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+            .flatMap { $0.windows }
+            .first { $0.isKeyWindow }
+        
+        keyWindow?.rootViewController?.present(alert, animated: true)
     }
 
     /// 앱이 **화면(Foreground)**에 켜져 있는 상태에서 푸시 알림이 왔을 때 호출됩니다.

--- a/Damago/Damago/Sources/Presentation/Features/MiniGame/CardGame/CardGameViewModel.swift
+++ b/Damago/Damago/Sources/Presentation/Features/MiniGame/CardGame/CardGameViewModel.swift
@@ -64,7 +64,6 @@ final class CardGameViewModel: ViewModel {
         input.alertConfirmDidTap
             .receive(on: DispatchQueue.main)
             .sink { [weak self] in
-                // FIXME: 클라우드 펑션 호출로 수정
                 self?.adjustCoinAmount()
             }
             .store(in: &cancellables)


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)를 적어주세요. 해당 이슈가 존재하지 않으면 생략 가능합니다.-->
- resolves #254 
- resolves #255 

## 🥑 작업 요약
<!-- 이번 PR에서 작업한 내용을 간략하게 설명해주세요.-->
- FIXME, TODO 주석 해소
    - APNS 기기토큰 등록 실패 재시도 및 알럿 표시

## 🛠️ 작업 내용
<!-- 어떻게 보다는 '왜' 이렇게 수정했는지, 의도를 중심으로 작성해주세요.
- 개발 과정에서 발생한 문제와 해결 방법, 대안 등을 정리하면 좋습니다.-->

### `CardGameViewModel` 주석 제거
- 이미 클라우드 함수 호출(`adjustCoinAmountUseCase`)이 정상적으로 구현되어 있으므로, stale한 `FIXME` 주석을 제거했습니다.

### `AppDelegate` APNs 예외 처리
- **재시도 로직 도입**: 네트워크 불안정 등으로 인한 일시적 등록 실패를 고려하여, 지수 백오프와 유사한 방식(2초, 4초, 6초)으로 최대 3회 재시도하도록 개선했습니다.
- **사용자 피드백(Alert)**: 재시도 횟수 초과 시, 사용자에게 알림이 제한될 수 있음을 알리는 알럿을 노출합니다.
- `UIWindowScene` 기반의 `isKeyWindow` 탐색 방식으로 최상위 뷰컨트롤러를 찾아 알럿을 표시합니다.

#### APNs 등록 실패 원인 (with Gemini, [자료 1](https://qkqtodn1.tistory.com/entry/iOS%EC%97%90%EC%84%9C-Flutter-Firebase-%ED%91%B8%EC%8B%9C-%EC%95%8C%EB%A6%BC-%EC%B6%A9%EB%8F%8C-APNs-%EC%98%A4%EB%A5%98-%ED%95%B4%EA%B2%B0-%EB%B0%A9%EB%B2%95), [자료 2](https://velog.io/@panther222128/Registering-Your-App-with-APNs))
- 시뮬레이터 사용:
    - 일반적인 iOS 시뮬레이터는 원격 푸시 알림(APNs)을 지원하지 않습니다. (단, M1/M2 칩셋의 Xcode 14+ 최신 환경에서는 일부 지원하지만 불안정할 수 있습니다.)
    - 해결: 실기기(Real Device)에서 테스트하세요.
- Signing & Capabilities 누락:
    - Xcode의 Project Target -> Signing & Capabilities 탭에서 Push Notifications 기능이 추가되어 있는지 확인하세요.
- 프로비저닝 프로파일 문제:
     - App ID 설정(Apple Developer Console)에서 Push Notification이 활성화되지 않았거나, 프로파일이 갱신되지 않았을 수 있습니다.
- 네트워크 제한:
     - 사내 방화벽이나 특정 와이파이 환경에서 APNs 포트(5223 등)가 차단된 경우 발생할 수 있습니다.

## ✅ 체크리스트
- [x] 빌드 및 실행 테스트를 완료했나요?
- [x] 불필요한 주석 및 Print 문을 제거했나요?
- [x] 코딩 컨벤션을 준수했나요?
