### PR TITLE
[#261] Firestore 경로 매직 스트링 관리

### DIFF
--- a/Damago/Damago/Sources/Data/Datasources/Firestore/FirestorePath.swift
+++ b/Damago/Damago/Sources/Data/Datasources/Firestore/FirestorePath.swift
@@ -1,0 +1,72 @@
+//
+//  FirestorePath.swift
+//  Damago
+//
+//  Created by 김재영 on 2/4/26.
+//
+
+enum FirestorePath {
+    private enum CollectionName {
+        static let users = "users"
+        static let couples = "couples"
+        static let damagos = "damagos"
+        static let dailyQuestionAnswers = "dailyQuestionAnswers"
+        static let balanceGameAnswers = "balanceGameAnswers"
+    }
+    
+    private enum FieldName {
+        static let coupleID = "coupleID"
+    }
+
+    case users(uid: String)
+    case couples(coupleID: String)
+    case damagos(damagoID: String)
+    case ownedDamagos(coupleID: String)
+    case dailyQuestionAnswers(coupleID: String, questionID: String)
+    case balanceGameAnswers(coupleID: String, gameID: String)
+
+    var fullPath: String {
+        document.isEmpty ? collection : "\(collection)/\(document)"
+    }
+    
+    var collection: String {
+        switch self {
+        case .users:
+            return CollectionName.users
+        case .couples:
+            return CollectionName.couples
+        case .damagos, .ownedDamagos:
+            return CollectionName.damagos
+        case .dailyQuestionAnswers(let coupleID, _):
+            return "\(CollectionName.couples)/\(coupleID)/\(CollectionName.dailyQuestionAnswers)"
+        case .balanceGameAnswers(let coupleID, _):
+            return "\(CollectionName.couples)/\(coupleID)/\(CollectionName.balanceGameAnswers)"
+        }
+    }
+    
+    var document: String {
+        switch self {
+        case .users(let uid):
+            return uid
+        case .couples(let coupleID):
+            return coupleID
+        case .damagos(let damagoID):
+            return damagoID
+        case .dailyQuestionAnswers(_, let questionID):
+            return questionID
+        case .balanceGameAnswers(_, let gameID):
+            return gameID
+        case .ownedDamagos:
+            return ""
+        }
+    }
+    
+    var queryInfo: (field: String, value: Any)? {
+        switch self {
+        case .ownedDamagos(let coupleID):
+            return (field: FieldName.coupleID, value: coupleID)
+        default:
+            return nil
+        }
+    }
+}

--- a/Damago/Damago/Sources/Data/Repository/BalanceGameRepository.swift
+++ b/Damago/Damago/Sources/Data/Repository/BalanceGameRepository.swift
@@ -114,9 +114,11 @@ final class BalanceGameRepository: BalanceGameRepositoryProtocol {
         option2: String,
         isUser1: Bool
     ) -> AnyPublisher<Result<BalanceGameDTO, Error>, Never> {
-        firestoreService.observe(
-            collection: "couples/\(coupleID)/balanceGameAnswers",
-            document: gameID
+        let firestorePath = FirestorePath.balanceGameAnswers(coupleID: coupleID, gameID: gameID)
+        
+        let publisher: AnyPublisher<Result<BalanceGameDTO, Error>, Never> = firestoreService.observe(
+            collection: firestorePath.collection,
+            document: firestorePath.document
         )
         .handleEvents(receiveOutput: { [weak self] result in
             if case .success(let response) = result {
@@ -162,6 +164,8 @@ final class BalanceGameRepository: BalanceGameRepositoryProtocol {
             }
         }
         .eraseToAnyPublisher()
+        
+        return publisher
     }
     // swiftlint:enable trailing_closure
 

--- a/Damago/Damago/Sources/Data/Repository/DailyQuestionRepository.swift
+++ b/Damago/Damago/Sources/Data/Repository/DailyQuestionRepository.swift
@@ -112,9 +112,11 @@ final class DailyQuestionRepository: DailyQuestionRepositoryProtocol {
         questionContent: String,
         isUser1: Bool
     ) -> AnyPublisher<Result<DailyQuestionDTO, Error>, Never> {
-        firestoreService.observe(
-            collection: "couples/\(coupleID)/dailyQuestionAnswers",
-            document: questionID
+        let firestorePath = FirestorePath.dailyQuestionAnswers(coupleID: coupleID, questionID: questionID)
+        
+        let publisher: AnyPublisher<Result<DailyQuestionDTO, Error>, Never> = firestoreService.observe(
+            collection: firestorePath.collection,
+            document: firestorePath.document
         )
         .handleEvents(receiveOutput: { [weak self] result in
             if case .success(let response) = result {
@@ -146,6 +148,8 @@ final class DailyQuestionRepository: DailyQuestionRepositoryProtocol {
             }
         }
         .eraseToAnyPublisher()
+        
+        return publisher
     }
     // swiftlint:enable trailing_closure
 

--- a/Damago/Damago/Sources/Data/Repository/DamagoRepository.swift
+++ b/Damago/Damago/Sources/Data/Repository/DamagoRepository.swift
@@ -56,10 +56,24 @@ final class DamagoRepository: DamagoRepositoryProtocol {
     }
 
     func observeDamagoSnapshot(damagoID: String) -> AnyPublisher<Result<DamagoSnapshotDTO, Error>, Never> {
-        firestoreService.observe(collection: "damagos", document: damagoID)
+        let firestorePath = FirestorePath.damagos(damagoID: damagoID)
+        
+        let publisher: AnyPublisher<Result<DamagoSnapshotDTO, Error>, Never> =
+        firestoreService.observe(collection: firestorePath.collection, document: firestorePath.document)
+        
+        return publisher
     }
 
     func observeOwnedDamagos(coupleID: String) -> AnyPublisher<Result<[DamagoSnapshotDTO], Error>, Never> {
-        firestoreService.observeQuery(collection: "damagos", field: "coupleID", value: coupleID)
+        let firestorePath = FirestorePath.ownedDamagos(coupleID: coupleID)
+        
+        guard let queryInfo = firestorePath.queryInfo else {
+            return Just(.failure(NSError(domain: "InvalidPath", code: -1))).eraseToAnyPublisher()
+        }
+        
+        let publisher: AnyPublisher<Result<[DamagoSnapshotDTO], Error>, Never> =
+        firestoreService.observeQuery(collection: firestorePath.collection, field: queryInfo.field, value: queryInfo.value)
+        
+        return publisher
     }
 }

--- a/Damago/Damago/Sources/Data/Repository/UserRepository.swift
+++ b/Damago/Damago/Sources/Data/Repository/UserRepository.swift
@@ -85,11 +85,21 @@ final class UserRepository: UserRepositoryProtocol {
     }
 
     func observeCoupleSnapshot(coupleID: String) -> AnyPublisher<Result<CoupleSnapshotDTO, Error>, Never> {
-        firestoreService.observe(collection: "couples", document: coupleID)
+        let firestorePath = FirestorePath.couples(coupleID: coupleID)
+        
+        let publisher: AnyPublisher<Result<CoupleSnapshotDTO, Error>, Never> =
+        firestoreService.observe(collection: firestorePath.collection, document: firestorePath.document)
+        
+        return publisher
     }
 
     func observeUserSnapshot(uid: String) -> AnyPublisher<Result<UserSnapshotDTO, Error>, Never> {
-        firestoreService.observe(collection: "users", document: uid)
+        let firestorePath = FirestorePath.users(uid: uid)
+        
+        let publisher: AnyPublisher<Result<UserSnapshotDTO, Error>, Never> =
+        firestoreService.observe(collection: firestorePath.collection, document: firestorePath.document)
+        
+        return publisher
     }
 
     func updateUserInfo(


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)를 적어주세요. 해당 이슈가 존재하지 않으면 생략 가능합니다.-->
- resolves #261 

## 🥑 작업 요약
<!-- 이번 PR에서 작업한 내용을 간략하게 설명해주세요.-->
- Firestore 문서 경로 매직 스트링 관리

## 🛠️ 작업 내용
<!-- 어떻게 보다는 '왜' 이렇게 수정했는지, 의도를 중심으로 작성해주세요.
- 개발 과정에서 발생한 문제와 해결 방법, 대안 등을 정리하면 좋습니다.-->

### FirestorePath
- 내부 private enum 을 정의하여 컬렉션 이름과 필드 이름을 관리해서 추후 확장 시 오타 가능성을 더 최소화했습니다.
    - 계층적 문서 생성 로직 또한 상수 조합으로 가독성과 오타 가능성이 최소화 되었습니다.
- 디버깅 용 fullPath 프로퍼티를 추가하였습니다.

## ✅ 체크리스트
- [x] 빌드 및 실행 테스트를 완료했나요?
- [x] 불필요한 주석 및 Print 문을 제거했나요?
- [x] 코딩 컨벤션을 준수했나요?
