### PR TITLE
[#289] Settings 뷰모델 테스트 작성

### DIFF
--- a/Damago/Damago/Sources/Presentation/Shared/Store/GlobalState.swift
+++ b/Damago/Damago/Sources/Presentation/Shared/Store/GlobalState.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct GlobalState: Equatable {
+nonisolated struct GlobalState: Equatable {
     // MARK: - User Content
     let nickname: String?
     let opponentName: String?

--- a/Damago/DamagoViewModelTests/EditProfileViewModelTests.swift
+++ b/Damago/DamagoViewModelTests/EditProfileViewModelTests.swift
@@ -1,0 +1,219 @@
+//
+//  EditProfileViewModelTests.swift
+//  DamagoViewModelTests
+//
+//  Created by 박현수 on 2/4/26.
+//
+
+import Testing
+import Combine
+import Foundation
+@testable import Damago
+
+@MainActor
+final class EditProfileViewModelTests {
+    private var cancellables = Set<AnyCancellable>()
+
+    private class FakeGlobalStore: GlobalStoreProtocol {
+        private let globalStateSubject = CurrentValueSubject<GlobalState, Never>(.empty)
+        var globalState: AnyPublisher<GlobalState, Never> {
+            globalStateSubject.eraseToAnyPublisher()
+        }
+
+        func updateState(_ state: GlobalState) {
+            globalStateSubject.send(state)
+        }
+
+        func startMonitoring(uid: String) {}
+        func stopMonitoring() {}
+    }
+
+    private class SpyUpdateUserUseCase: UpdateUserUseCase {
+        var executeCalled = false
+        var lastNickname: String?
+        var lastAnniversaryDate: Date?
+        var shouldFail = false
+        
+        private let continuation: AsyncStream<Void>.Continuation
+        let executedStream: AsyncStream<Void>
+
+        init() {
+            var cont: AsyncStream<Void>.Continuation!
+            self.executedStream = AsyncStream { cont = $0 }
+            self.continuation = cont
+        }
+
+        func execute(
+            nickname: String?,
+            anniversaryDate: Date?,
+            useFCM: Bool?,
+            useLiveActivity: Bool?,
+            damagoName: String?,
+            damagoType: DamagoType?
+        ) async throws {
+            executeCalled = true
+            self.lastNickname = nickname
+            self.lastAnniversaryDate = anniversaryDate
+            
+            if shouldFail {
+                continuation.yield()
+                throw NSError(domain: "test", code: -1, userInfo: [NSLocalizedDescriptionKey: "Update failed"])
+            }
+            
+            continuation.yield()
+        }
+    }
+
+    struct TestInput {
+        let viewDidLoad = PassthroughSubject<Void, Never>()
+        let nicknameChanged = PassthroughSubject<String, Never>()
+        let dateChanged = PassthroughSubject<Date, Never>()
+        let saveButtonDidTap = PassthroughSubject<Void, Never>()
+
+        var input: EditProfileViewModel.Input {
+            EditProfileViewModel.Input(
+                viewDidLoad: viewDidLoad.eraseToAnyPublisher(),
+                nicknameChanged: nicknameChanged.eraseToAnyPublisher(),
+                dateChanged: dateChanged.eraseToAnyPublisher(),
+                saveButtonDidTap: saveButtonDidTap.eraseToAnyPublisher()
+            )
+        }
+    }
+
+    @Test("GlobalState의 닉네임과 기념일이 ViewModel State에 반영되어야 한다")
+    func testGlobalStateBinding() async throws {
+        // Given
+        let fakeGlobalStore = FakeGlobalStore()
+        let viewModel = EditProfileViewModel(
+            globalStore: fakeGlobalStore,
+            updateUserUseCase: SpyUpdateUserUseCase()
+        )
+        let testInput = TestInput()
+        let output = viewModel.transform(testInput.input)
+
+        let testDate = Date(timeIntervalSince1970: 1000)
+        let newState = GlobalState(
+            nickname: "InitialName",
+            opponentName: nil,
+            useFCM: false,
+            useLiveActivity: false,
+            coupleID: nil, totalCoin: nil, foodCount: nil,
+            anniversaryDate: testDate,
+            currentQuestionID: nil, damagoID: nil, damagoName: nil, damagoType: nil,
+            level: nil, currentExp: nil, maxExp: nil, isHungry: nil, statusMessage: nil,
+            lastFedAt: nil, totalPlayTime: nil, lastActiveAt: nil, ownedDamagos: nil
+        )
+
+        // When
+        testInput.viewDidLoad.send()
+        fakeGlobalStore.updateState(newState)
+
+        // Then
+        try await withTimeout(seconds: 1.0) { @MainActor in
+            var outputIterator = output.values.makeAsyncIterator()
+
+            while let state = await outputIterator.next() {
+                if state.nickname == "InitialName" && state.anniversaryDate == testDate {
+                    #expect(state.nickname == "InitialName")
+                    #expect(state.anniversaryDate == testDate)
+                    return
+                }
+            }
+        }
+    }
+
+    @Test("닉네임 변경 입력이 State에 반영되어야 한다")
+    func testNicknameChange() async throws {
+        // Given
+        let viewModel = EditProfileViewModel(
+            globalStore: FakeGlobalStore(),
+            updateUserUseCase: SpyUpdateUserUseCase()
+        )
+        let testInput = TestInput()
+        let output = viewModel.transform(testInput.input)
+
+        // When
+        testInput.nicknameChanged.send("NewNickname")
+
+        // Then
+        try await withTimeout(seconds: 1.0) {
+            var outputIterator = output.values.makeAsyncIterator()
+
+            while let state = await outputIterator.next() {
+                if await state.nickname == "NewNickname" {
+                    #expect(state.nickname == "NewNickname")
+                    #expect(state.isSaveEnabled == true)
+                    return
+                }
+            }
+        }
+    }
+
+    @Test("저장 버튼 클릭 시 UpdateUserUseCase가 호출되고 back으로 이동해야 한다")
+    func testSaveProfileSuccess() async throws {
+        // Given
+        let spyUpdateUserUseCase = SpyUpdateUserUseCase()
+        let viewModel = EditProfileViewModel(
+            globalStore: FakeGlobalStore(),
+            updateUserUseCase: spyUpdateUserUseCase
+        )
+        let testInput = TestInput()
+        let output = viewModel.transform(testInput.input)
+
+        let newNickname = "UpdatedName"
+        let newDate = Date()
+
+        // When
+        testInput.nicknameChanged.send(newNickname)
+        testInput.dateChanged.send(newDate)
+        testInput.saveButtonDidTap.send()
+
+        // Then: UseCase 호출 확인
+        try await withTimeout(seconds: 1.0) {
+            var spyIterator = spyUpdateUserUseCase.executedStream.makeAsyncIterator()
+            _ = await spyIterator.next()
+            #expect(spyUpdateUserUseCase.executeCalled == true)
+            #expect(spyUpdateUserUseCase.lastNickname == newNickname)
+            #expect(spyUpdateUserUseCase.lastAnniversaryDate == newDate)
+        }
+
+        // Then: Route 확인
+        try await withTimeout(seconds: 1.0) {
+            var outputIterator = output.values.makeAsyncIterator()
+            while let state = await outputIterator.next() {
+                if let route = await state.route?.value, case .back = route {
+                    #expect(true)
+                    return
+                }
+            }
+        }
+    }
+
+    @Test("저장 실패 시 에러 루트가 설정되어야 한다")
+    func testSaveProfileFailure() async throws {
+        // Given
+        let spyUpdateUserUseCase = SpyUpdateUserUseCase()
+        spyUpdateUserUseCase.shouldFail = true
+        let viewModel = EditProfileViewModel(
+            globalStore: FakeGlobalStore(),
+            updateUserUseCase: spyUpdateUserUseCase
+        )
+        let testInput = TestInput()
+        let output = viewModel.transform(testInput.input)
+
+        // When
+        testInput.nicknameChanged.send("SomeName")
+        testInput.saveButtonDidTap.send()
+
+        // Then: Error Route 확인
+        try await withTimeout(seconds: 1.0) {
+            var outputIterator = output.values.makeAsyncIterator()
+            while let state = await outputIterator.next() {
+                if let route = await state.route?.value, case .error = route {
+                    #expect(true)
+                    return
+                }
+            }
+        }
+    }
+}

--- a/Damago/DamagoViewModelTests/SettingsViewModelTests.swift
+++ b/Damago/DamagoViewModelTests/SettingsViewModelTests.swift
@@ -2,7 +2,7 @@
 //  SettingsViewModelTests.swift
 //  DamagoViewModelTests
 //
-//  Created by Gemini on 2/4/26.
+//  Created by 박현수 on 2/4/26.
 //
 
 import Testing
@@ -136,14 +136,12 @@ final class SettingsViewModelTests {
 
         // When
         testInput.viewDidLoad.send()
-        
 
         fakeGlobalStore.updateState(newState)
         
         // Then: 1초 내에 "TestUser"가 되는지 확인
         try await withTimeout(seconds: 1.0) {
             var outputIterator = output.values.makeAsyncIterator()
-            _ = await outputIterator.next()
 
             while let state = await outputIterator.next() {
                 if await state.userName == "TestUser" {
@@ -172,7 +170,6 @@ final class SettingsViewModelTests {
         // Then
         try await withTimeout(seconds: 1.0) {
             var outputIterator = output.values.makeAsyncIterator()
-            _ = await outputIterator.next()
 
             while let state = await outputIterator.next() {
                 if let route = await state.route?.value, case .editProfile = route {
@@ -256,20 +253,3 @@ final class SettingsViewModelTests {
         }
     }
 }
-
-/// 타임아웃을 적용하는 헬퍼 함수
-func withTimeout(seconds: TimeInterval, operation: @escaping @Sendable () async -> Void) async throws {
-    try await withThrowingTaskGroup(of: Void.self) { group in
-        group.addTask {
-            await operation()
-        }
-        group.addTask {
-            try await Task.sleep(for: .seconds(seconds))
-            throw TimeoutError()
-        }
-        try await group.next()
-        group.cancelAll()
-    }
-}
-
-struct TimeoutError: Error {}

--- a/Damago/DamagoViewModelTests/SettingsViewModelTests.swift
+++ b/Damago/DamagoViewModelTests/SettingsViewModelTests.swift
@@ -1,0 +1,275 @@
+//
+//  SettingsViewModelTests.swift
+//  DamagoViewModelTests
+//
+//  Created by Gemini on 2/4/26.
+//
+
+import Testing
+import Combine
+import Foundation
+@testable import Damago
+
+@MainActor
+final class SettingsViewModelTests {
+    private var cancellables = Set<AnyCancellable>()
+
+    private class FakeGlobalStore: GlobalStoreProtocol {
+        private let globalStateSubject = CurrentValueSubject<GlobalState, Never>(.empty)
+        var globalState: AnyPublisher<GlobalState, Never> {
+            globalStateSubject.eraseToAnyPublisher()
+        }
+
+        func updateState(_ state: GlobalState) {
+            globalStateSubject.send(state)
+        }
+
+        func startMonitoring(uid: String) {}
+        func stopMonitoring() {}
+    }
+
+    private class SpySignOutUseCase: SignOutUseCase {
+        var executeCalled = false
+        private let continuation: AsyncStream<Void>.Continuation
+        let executedStream: AsyncStream<Void>
+
+        init() {
+            var cont: AsyncStream<Void>.Continuation!
+            self.executedStream = AsyncStream { cont = $0 }
+            self.continuation = cont
+        }
+
+        func execute() throws {
+            executeCalled = true
+            continuation.yield()
+        }
+    }
+
+    private class SpyWithdrawUseCase: WithdrawUseCase {
+        var executeCalled = false
+        private let continuation: AsyncStream<Void>.Continuation
+        let executedStream: AsyncStream<Void>
+
+        init() {
+            var cont: AsyncStream<Void>.Continuation!
+            self.executedStream = AsyncStream { cont = $0 }
+            self.continuation = cont
+        }
+
+        func execute() async throws {
+            executeCalled = true
+            continuation.yield()
+        }
+    }
+
+    private class SpyUpdateUserUseCase: UpdateUserUseCase {
+        var executeCalled = false
+        var lastUseFCM: Bool?
+        var lastUseLiveActivity: Bool?
+        
+        private let continuation: AsyncStream<Void>.Continuation
+        let executedStream: AsyncStream<Void>
+
+        init() {
+            var cont: AsyncStream<Void>.Continuation!
+            self.executedStream = AsyncStream { cont = $0 }
+            self.continuation = cont
+        }
+
+        func execute(
+            nickname: String?,
+            anniversaryDate: Date?,
+            useFCM: Bool?,
+            useLiveActivity: Bool?,
+            damagoName: String?,
+            damagoType: DamagoType?
+        ) async throws {
+            executeCalled = true
+            self.lastUseFCM = useFCM
+            self.lastUseLiveActivity = useLiveActivity
+            continuation.yield()
+        }
+    }
+
+    struct TestInput {
+        let viewDidLoad = PassthroughSubject<Void, Never>()
+        let toggleChanged = PassthroughSubject<(ToggleType, Bool), Never>()
+        let itemSelected = PassthroughSubject<SettingsItem, Never>()
+        let damagoBackgroundChanged = PassthroughSubject<DamagoBackgroundColorOption, Never>()
+        let alertActionDidConfirm = PassthroughSubject<AlertActionType, Never>()
+
+        var input: SettingsViewModel.Input {
+            SettingsViewModel.Input(
+                viewDidLoad: viewDidLoad.eraseToAnyPublisher(),
+                toggleChanged: toggleChanged.eraseToAnyPublisher(),
+                itemSelected: itemSelected.eraseToAnyPublisher(),
+                damagoBackgroundChanged: damagoBackgroundChanged.eraseToAnyPublisher(),
+                alertActionDidConfirm: alertActionDidConfirm.eraseToAnyPublisher()
+            )
+        }
+    }
+
+    @Test("GlobalState 변화가 ViewModel State에 반영되어야 한다")
+    func testGlobalStateBinding() async throws {
+        // Given
+        let fakeGlobalStore = FakeGlobalStore()
+        let viewModel = SettingsViewModel(
+            globalStore: fakeGlobalStore,
+            signOutUseCase: SpySignOutUseCase(),
+            withdrawUseCase: SpyWithdrawUseCase(),
+            updateUserUseCase: SpyUpdateUserUseCase()
+        )
+        let testInput = TestInput()
+        let output = viewModel.transform(testInput.input)
+
+        let newState = GlobalState(
+            nickname: "TestUser",
+            opponentName: "Opponent",
+            useFCM: true,
+            useLiveActivity: false,
+            coupleID: nil, totalCoin: nil, foodCount: nil, anniversaryDate: Date(),
+            currentQuestionID: nil, damagoID: nil, damagoName: nil, damagoType: nil,
+            level: nil, currentExp: nil, maxExp: nil, isHungry: nil, statusMessage: nil,
+            lastFedAt: nil, totalPlayTime: nil, lastActiveAt: nil, ownedDamagos: nil
+        )
+        
+
+        // When
+        testInput.viewDidLoad.send()
+        
+
+        fakeGlobalStore.updateState(newState)
+        
+        // Then: 1초 내에 "TestUser"가 되는지 확인
+        try await withTimeout(seconds: 1.0) {
+            var outputIterator = output.values.makeAsyncIterator()
+            _ = await outputIterator.next()
+
+            while let state = await outputIterator.next() {
+                if await state.userName == "TestUser" {
+                    #expect(state.userName == "TestUser")
+                    return
+                }
+            }
+        }
+    }
+
+    @Test("설정 아이템 선택 시 적절한 Route가 설정되어야 한다")
+    func testItemSelectionRouting() async throws {
+        // Given
+        let viewModel = SettingsViewModel(
+            globalStore: FakeGlobalStore(),
+            signOutUseCase: SpySignOutUseCase(),
+            withdrawUseCase: SpyWithdrawUseCase(),
+            updateUserUseCase: SpyUpdateUserUseCase()
+        )
+        let testInput = TestInput()
+        let output = viewModel.transform(testInput.input)
+
+        // When
+        testInput.itemSelected.send(.profile(name: "", dDay: 0, anniversaryDate: ""))
+        
+        // Then
+        try await withTimeout(seconds: 1.0) {
+            var outputIterator = output.values.makeAsyncIterator()
+            _ = await outputIterator.next()
+
+            while let state = await outputIterator.next() {
+                if let route = await state.route?.value, case .editProfile = route {
+                    #expect(true)
+                    return
+                }
+            }
+        }
+    }
+    
+    @Test("로그아웃 확인 시 SignOutUseCase가 실행되어야 한다")
+    func testSignOutExecution() async throws {
+        // Given
+        let spySignOutUseCase = SpySignOutUseCase()
+        let viewModel = SettingsViewModel(
+            globalStore: FakeGlobalStore(),
+            signOutUseCase: spySignOutUseCase,
+            withdrawUseCase: SpyWithdrawUseCase(),
+            updateUserUseCase: SpyUpdateUserUseCase()
+        )
+        let testInput = TestInput()
+        let _ = viewModel.transform(testInput.input)
+
+        // When
+        testInput.alertActionDidConfirm.send(.logout)
+        
+        // Then
+        try await withTimeout(seconds: 1.0) {
+            var spyIterator = spySignOutUseCase.executedStream.makeAsyncIterator()
+            _ = await spyIterator.next()
+            #expect(spySignOutUseCase.executeCalled == true)
+        }
+    }
+
+    @Test("회원탈퇴 확인 시 WithdrawUseCase가 실행되어야 한다")
+    func testWithdrawExecution() async throws {
+        // Given
+        let spyWithdrawUseCase = SpyWithdrawUseCase()
+        let viewModel = SettingsViewModel(
+            globalStore: FakeGlobalStore(),
+            signOutUseCase: SpySignOutUseCase(),
+            withdrawUseCase: spyWithdrawUseCase,
+            updateUserUseCase: SpyUpdateUserUseCase()
+        )
+        let testInput = TestInput()
+        let _ = viewModel.transform(testInput.input)
+
+        // When
+        testInput.alertActionDidConfirm.send(.deleteAccount)
+        
+        // Then
+        try await withTimeout(seconds: 1.0) {
+            var spyIterator = spyWithdrawUseCase.executedStream.makeAsyncIterator()
+            _ = await spyIterator.next()
+            #expect(spyWithdrawUseCase.executeCalled == true)
+        }
+    }
+    
+    @Test("토글 OFF 시 UpdateUserUseCase가 호출되어야 한다")
+    func testToggleOffUpdatesServer() async throws {
+        // Given
+        let spyUpdateUserUseCase = SpyUpdateUserUseCase()
+        let viewModel = SettingsViewModel(
+            globalStore: FakeGlobalStore(),
+            signOutUseCase: SpySignOutUseCase(),
+            withdrawUseCase: SpyWithdrawUseCase(),
+            updateUserUseCase: spyUpdateUserUseCase
+        )
+        let testInput = TestInput()
+        let _ = viewModel.transform(testInput.input)
+
+        // When
+        testInput.toggleChanged.send((.notification, false))
+        
+        // Then
+        try await withTimeout(seconds: 1.0) {
+            var spyIterator = spyUpdateUserUseCase.executedStream.makeAsyncIterator()
+            _ = await spyIterator.next()
+            #expect(spyUpdateUserUseCase.executeCalled == true)
+            #expect(spyUpdateUserUseCase.lastUseFCM == false)
+        }
+    }
+}
+
+/// 타임아웃을 적용하는 헬퍼 함수
+func withTimeout(seconds: TimeInterval, operation: @escaping @Sendable () async -> Void) async throws {
+    try await withThrowingTaskGroup(of: Void.self) { group in
+        group.addTask {
+            await operation()
+        }
+        group.addTask {
+            try await Task.sleep(for: .seconds(seconds))
+            throw TimeoutError()
+        }
+        try await group.next()
+        group.cancelAll()
+    }
+}
+
+struct TimeoutError: Error {}

--- a/Damago/DamagoViewModelTests/Utils.swift
+++ b/Damago/DamagoViewModelTests/Utils.swift
@@ -1,0 +1,25 @@
+//
+//  Utils.swift
+//  Damago
+//
+//  Created by 박현수 on 2/4/26.
+//
+
+import Foundation
+
+/// 타임아웃을 적용하는 헬퍼 함수
+func withTimeout(seconds: TimeInterval, operation: @escaping @Sendable () async -> Void) async throws {
+    try await withThrowingTaskGroup(of: Void.self) { group in
+        group.addTask {
+            await operation()
+        }
+        group.addTask {
+            try await Task.sleep(for: .seconds(seconds))
+            throw TimeoutError()
+        }
+        try await group.next()
+        group.cancelAll()
+    }
+}
+
+struct TimeoutError: Error {}


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)를 적어주세요. 해당 이슈가 존재하지 않으면 생략 가능합니다.-->
- resolves #289

## 🥑 작업 요약
<!-- 이번 PR에서 작업한 내용을 간략하게 설명해주세요.-->
- Settings 뷰모델 테스트 작성
  
## 🛠️ 작업 내용
### 1. ViewModel Unit Test 추가
- **`SettingsViewModelTests` 추가:** 설정 화면의 주요 로직(화면 이동, 토글 변경, 로그아웃/회원탈퇴 등)을 검증하는 테스트 코드를 작성했습니다.
- **`EditProfileViewModelTests` 추가:** 프로필 수정 화면의 상태 바인딩, 유효성 검사, 저장 로직을 검증하는 테스트 코드를 작성했습니다.
- **`Utils.swift` 추가:** 비동기 테스트 시 타임아웃을 처리하기 위한 `withTimeout` 헬퍼 함수를 추가하여 테스트 안정성을 높였습니다.

### 2. GlobalState 구조 수정
- **`nonisolated` 키워드 추가:** `GlobalState` 구조체에 `nonisolated`를 명시하여 테스트 코드 및 다양한 컨텍스트에서 접근 시 발생할 수 있는 격리(isolation) 문제를 방지했습니다.

## ✅ 체크리스트
- [x] 빌드 및 실행 테스트를 완료했나요?
- [x] 불필요한 주석 및 Print 문을 제거했나요?
- [x] 코딩 컨벤션을 준수했나요?