### PR TITLE
[#46] CI 개선

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    # Ruby 환경 설정 (Fastlane 구동용)
+    # Ruby 환경 설정
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
@@ -25,8 +25,7 @@ jobs:
     - name: Select Xcode 26.1
       run: sudo xcode-select -s /Applications/Xcode_26.1.app/Contents/Developer
 
-    # .gitignore로 누락된 파일 생성
-    # 실제 CI 동작을 위해 GitHub Secrets 설정
+    # GoogleService-Info.plist 생성
     - name: Create GoogleService-Info.plist
       run: |
         mkdir -p ./Damago/Damago/Resources
@@ -44,14 +43,19 @@ jobs:
         xcrun simctl shutdown all
         xcrun simctl erase all
 
-    - name: Clean Xcode Derived Data & Package Cache
-      run: |
-        rm -rf ~/Library/Developer/Xcode/DerivedData
-        rm -rf ~/Library/Caches/org.swift.swiftpm
-        rm -rf ./Damago/Damago.xcodeproj/project.xcworkspace/xcshareddata/swiftpm
+    # [추가] SPM 캐시 적용 (DerivedData 및 SPM 캐시 저장/복구)
+    - name: Cache Xcode DerivedData & SwiftPM
+      uses: actions/cache@v3
+      with:
+        path: |
+          ~/Library/Developer/Xcode/DerivedData
+          ~/Library/Caches/org.swift.swiftpm
+        # Package.resolved 파일이 변경될 때만 캐시를 새로 생성
+        key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}
+        restore-keys: |
+          ${{ runner.os }}-spm-
 
-    # Fastlane 실행 전, 패키지(Firebase 등)를 미리 해결(Resolve)
-    # -list 명령어가 타임아웃 나지 않도록 의존성을 먼저 다운로드합니다.
+    # 패키지 해결 (캐시가 있으면 매우 빠르게 넘어감)
     - name: Resolve Package Dependencies
       run: |
         xcodebuild -resolvePackageDependencies \
@@ -59,8 +63,8 @@ jobs:
           -scheme Damago \
           -configuration Debug
 
+    # Fastlane 실행
     - name: Run Fastlane Tests
-      # CI 환경에서도 Xcode 설정을 읽어오는 시간을 충분히 확보
       env:
         FASTLANE_XCODE_LIST_TIMEOUT: 120
         FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT: 120

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -22,7 +22,7 @@ platform :ios do
       scheme: "Damago",
       configuration: "Debug",
       device: device_name,
-      clean: true,
+      clean: false,
       
       # [핵심] 30분 타임아웃 방지를 위해 병렬 테스트 비활성화
       xcargs: "-skipPackagePluginValidation -parallel-testing-enabled NO"
@@ -41,13 +41,13 @@ platform :ios do
         project: "./Damago/Damago.xcodeproj",
         scheme: "Damago",
         configuration: "Release",
-        clean: true,
+        clean: false,
         build: true,      # 테스트 없이 빌드 액션만 수행
         analyze: false,   # 정적 분석 생략 (속도 향상)
         
         # CI에 인증서 세팅이 없어도 빌드가 터지지 않도록 '시뮬레이터'용으로 빌드
         destination: "platform=iOS Simulator,name=#{device_name}",
-        xcargs: "-skipPackagePluginValidation"
+        xcargs: "-skipPackagePluginValidation RUN_CLANG_STATIC_ANALYZER=NO"
       )
     end
   end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -25,7 +25,7 @@ platform :ios do
       clean: false,
       
       # [핵심] 30분 타임아웃 방지를 위해 병렬 테스트 비활성화
-      xcargs: "-skipPackagePluginValidation -parallel-testing-enabled NO"
+      xcargs: "-skipPackagePluginValidation -parallel-testing-enabled NO ARCHS=arm64"
     )
 
     # ----------------------------------------------------------------
@@ -47,7 +47,7 @@ platform :ios do
         
         # CI에 인증서 세팅이 없어도 빌드가 터지지 않도록 '시뮬레이터'용으로 빌드
         destination: "platform=iOS Simulator,name=#{device_name}",
-        xcargs: "-skipPackagePluginValidation RUN_CLANG_STATIC_ANALYZER=NO"
+        xcargs: "-skipPackagePluginValidation RUN_CLANG_STATIC_ANALYZER=NO ARCHS=arm64"
       )
     end
   end


### PR DESCRIPTION
## 📌 관련 이슈
- resolves #46 

## 🥑 작업 요약
- CI/CD 파이프라인의 빌드 속도를 개선하기 위해 GitHub Actions 캐싱(Cache)을 도입
- 불필요한 정적 분석(Analyze) 단계를 비활성화

## 🛠️ 작업 내용
### 1. GitHub Actions 캐시 도입 (ci.yml)
- 변경 이유: 매 빌드마다 Firebase 등 무거운 의존성을 새로 컴파일하여 빌드 시간이 과도하게 소요되는 문제가 있었습니다.
- 작업 내용:
    - DerivedData 및 SwiftPM 캐시를 저장하고 복구하는 actions/cache 단계를 추가했습니다.
    - 캐시 활용을 위해 기존의 강제 삭제 명령어(rm -rf DerivedData...)를 제거했습니다.

### 2. Fastlane 설정 최적화 (Fastfile)
- 변경 이유: Release 빌드 검증 시 불필요한 analyze 단계가 실행되어 시간이 지연되었으며, clean: true 설정이 캐시 효율을 떨어뜨렸습니다.
- 작업 내용:
     - analyze: false 옵션을 명시하고, Xcode 빌드 세팅에 RUN_CLANG_STATIC_ANALYZER=NO를 주입하여 분석을 강제로 차단했습니다.
     - 캐시된 빌드 산출물을 재사용하기 위해 clean: false로 변경했습니다.

## ✅ 체크리스트
- [x] 빌드 및 실행 테스트를 완료했나요?
- [x] 불필요한 주석 및 Print 문을 제거했나요?
- [x] 코딩 컨벤션을 준수했나요?