### PR TITLE
[#262] 로그인 뷰에서 커플 연결 여부를 체크하여 메인화면으로 이동

### DIFF
--- a/Damago/Damago/Sources/Application/SceneDelegate.swift
+++ b/Damago/Damago/Sources/Application/SceneDelegate.swift
@@ -66,6 +66,7 @@ final class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         } else {
             let signInVM = SignInViewModel(
                 signInUseCase: AppDIContainer.shared.resolve(SignInUseCase.self),
+                checkConnectionUseCase: AppDIContainer.shared.resolve(CheckConnectionUseCase.self),
                 opponentCode: code
             )
             let signInVC = SignInViewController(viewModel: signInVM)
@@ -92,7 +93,10 @@ final class SceneDelegate: UIResponder, UIWindowSceneDelegate {
                 }
             }
         } else {
-            let signInVM = SignInViewModel(signInUseCase: AppDIContainer.shared.resolve(SignInUseCase.self))
+            let signInVM = SignInViewModel(
+                signInUseCase: AppDIContainer.shared.resolve(SignInUseCase.self),
+                checkConnectionUseCase: AppDIContainer.shared.resolve(CheckConnectionUseCase.self)
+            )
             let signInVC = SignInViewController(viewModel: signInVM)
             let navigationController = UINavigationController(rootViewController: signInVC)
             navigationController.setNavigationBarHidden(true, animated: false)

--- a/Damago/Damago/Sources/Presentation/Features/SignIn/SignInViewController.swift
+++ b/Damago/Damago/Sources/Presentation/Features/SignIn/SignInViewController.swift
@@ -7,6 +7,7 @@
 
 import Combine
 import UIKit
+import FirebaseAuth
 
 final class SignInViewController: UIViewController {
     private let mainView = SignInView()
@@ -53,6 +54,8 @@ final class SignInViewController: UIViewController {
                     presentAlert(message: errorMessage)
                 case let .connection(opponentCode):
                     navigateToConnection(code: opponentCode)
+                case .tabBar:
+                    navigateToTabBar()
                 }
             }
             .store(in: &cancellables)
@@ -68,6 +71,13 @@ final class SignInViewController: UIViewController {
         present(alert, animated: true, completion: nil)
     }
 
+    private func navigateToTabBar() {
+        UserDefaults.standard.set(true, forKey: "isOnboardingCompleted")
+        let globalStore = AppDIContainer.shared.resolve(GlobalStoreProtocol.self)
+        startGlobalMonitoring()
+        view.window?.rootViewController = TabBarViewController()
+    }
+
     private func navigateToConnection(code: String?) {
         let fetchCodeUseCase = AppDIContainer.shared.resolve(FetchCodeUseCase.self)
         let connectCoupleUseCase = AppDIContainer.shared.resolve(ConnectCoupleUseCase.self)
@@ -78,5 +88,11 @@ final class SignInViewController: UIViewController {
         )
         let connectionVC = ConnectionViewController(viewModel: connectionVM)
         navigationController?.pushViewController(connectionVC, animated: true)
+    }
+
+    private func startGlobalMonitoring() {
+        guard let uid = Auth.auth().currentUser?.uid else { return }
+        let globalStore = AppDIContainer.shared.resolve(GlobalStoreProtocol.self)
+        globalStore.startMonitoring(uid: uid)
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)를 적어주세요. 해당 이슈가 존재하지 않으면 생략 가능합니다.-->
- resolves #262 

## 🥑 작업 요약
로그아웃 후 재로그인 시 프로필 설정을 새로 하게 되는 흐름을 수정했습니다.
<!-- 이번 PR에서 작업한 내용을 간략하게 설명해주세요.-->

## 🛠️ 작업 내용
<img width="450" alt="63448" src="https://github.com/user-attachments/assets/469752d0-33b0-4810-87ea-e22716dda300" />

흐름을 점검해본 결과 기존엔 로그아웃을 할 경우 `isOnboardingCompleted`를 `false`로 변경하고 `SingInView`로 라우트하고 있었습니다.  
이에 `isOnboardingCompleted`가 사용되는 지점을 확인해보니 `SceneDelegate`의 `setupRootViewController` 내부에서 사용되고 있었습니다.  
이는 앱을 재실행 시에만 통과하는 경로였으며 로그아웃-로그인을 바로 이어서 진행할 경우 `SignInView`에서 곧바로 `ConnectionView`로 이동하고 있는 것이 정확한 원인이었습니다. 

참고로 `SceneDelegate`의 `setupRootViewController` 메서드 내부에서는 `checkConnectionUseCase`를 이용해 서버에서 연결 여부를 체크하고 프로필 세팅 화면 또는 메인 탭바로 이동하고 있었습니다.  
여기서 커플 연결이 되어있는 경우엔 로그아웃 시 `false`로 설정되었던 `isOnboardingCompleted`에 따라 프로필 설정화면으로 이동하는 것을 확인했습니다. 

결론적으로 로그인 이후 반드시 커플 연결-프로필 설정으로 이어지는 부분이 문제라고 판단했고, `SignInView`에서도 `SceneDelegate`와 동일하게 서버에서 커플 연결 여부를 확인한 뒤 곧바로 메인 화면으로 이동할 수 있도록 분기를 추가했습니다. 

|로그아웃 후 로그인 시 곧바로 메인화면 이동|프로필 설정 중 앱 재시작해도 유지하는 부분 보존|
|---|---|
|<img src="https://github.com/user-attachments/assets/85e8132c-e63d-4080-b64f-ef4bcbe702a4" width="300" alt=""> |<img src="https://github.com/user-attachments/assets/064b6b24-ec8a-426b-911d-586868e5d06e" width="300" alt=""> |

## 🧪 테스트 방법
<!-- 리뷰어가 변경 사항을 확인할 수 있는 방법을 서술합니다. -->
- [x] 커플 연결이 된 아이디로 로그아웃 후 재로그인 시 곧바로 메인 탭 화면으로 이동하는지 확인하시면 될 듯 합니다.

## ✅ 체크리스트
- [x] 빌드 및 실행 테스트를 완료했나요?
- [x] 불필요한 주석 및 Print 문을 제거했나요?
- [x] 코딩 컨벤션을 준수했나요?
