### PR TITLE
[#290] SigninViewModel 테스트 코드 작성

### DIFF
--- a/Damago/Damago.xcodeproj/xcshareddata/xcschemes/Damago.xcscheme
+++ b/Damago/Damago.xcodeproj/xcshareddata/xcschemes/Damago.xcscheme
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "2610"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "4B5FE2D32EF130B6005E31DA"
+               BuildableName = "Damago.app"
+               BlueprintName = "Damago"
+               ReferencedContainer = "container:Damago.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "4B4640752F308262005E4F34"
+               BuildableName = "DamagoViewModelTests.xctest"
+               BlueprintName = "DamagoViewModelTests"
+               ReferencedContainer = "container:Damago.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "4B5FE2D32EF130B6005E31DA"
+            BuildableName = "Damago.app"
+            BlueprintName = "Damago"
+            ReferencedContainer = "container:Damago.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "4B5FE2D32EF130B6005E31DA"
+            BuildableName = "Damago.app"
+            BlueprintName = "Damago"
+            ReferencedContainer = "container:Damago.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Damago/Damago/Sources/Domain/UseCase/SignInUseCase.swift
+++ b/Damago/Damago/Sources/Domain/UseCase/SignInUseCase.swift
@@ -6,7 +6,7 @@
 //
 
 protocol SignInUseCase {
-    func signIn() async throws
+    func execute() async throws
 }
 
 final class SignInUseCaseImpl: SignInUseCase {
@@ -16,7 +16,7 @@ final class SignInUseCaseImpl: SignInUseCase {
         self.repository = repository
     }
 
-    func signIn() async throws {
+    func execute() async throws {
         try await repository.signIn()
         try await repository.updateFCMToken(fcmToken: nil)
     }

--- a/Damago/Damago/Sources/Presentation/Features/SignIn/SignInViewController.swift
+++ b/Damago/Damago/Sources/Presentation/Features/SignIn/SignInViewController.swift
@@ -73,7 +73,6 @@ final class SignInViewController: UIViewController {
 
     private func navigateToTabBar() {
         UserDefaults.standard.set(true, forKey: "isOnboardingCompleted")
-        let globalStore = AppDIContainer.shared.resolve(GlobalStoreProtocol.self)
         startGlobalMonitoring()
         view.window?.rootViewController = TabBarViewController()
     }

--- a/Damago/Damago/Sources/Presentation/Features/SignIn/SignInViewModel.swift
+++ b/Damago/Damago/Sources/Presentation/Features/SignIn/SignInViewModel.swift
@@ -63,7 +63,7 @@ final class SignInViewModel: ViewModel {
 
     func signIn() async {
         do {
-            try await signInUseCase.signIn()
+            try await signInUseCase.execute()
             let isConnected = try await checkConnectionUseCase.execute()
             if isConnected {
                 self.state.route = .init(.tabBar)

--- a/Damago/DamagoViewModelTests/SignInViewModelTests.swift
+++ b/Damago/DamagoViewModelTests/SignInViewModelTests.swift
@@ -22,7 +22,7 @@ final class SignInViewModelTests {
         var executeResult: Result<Void, Error> = .success(())
         var onExecute: (() -> Void)?
         
-        func signIn() async throws {
+        func execute() async throws {
             executeCalled = true
             onExecute?()
             switch executeResult {

--- a/Damago/DamagoViewModelTests/SignInViewModelTests.swift
+++ b/Damago/DamagoViewModelTests/SignInViewModelTests.swift
@@ -34,6 +34,22 @@ final class SignInViewModelTests {
         }
     }
 
+    @MainActor
+    class MockCheckConnectionUseCase: CheckConnectionUseCase {
+        var executeCalled = false
+        var executeResult: Result<Bool, Error> = .success(false)
+        
+        func execute() async throws -> Bool {
+            executeCalled = true
+            switch executeResult {
+            case .success(let isConnected):
+                return isConnected
+            case .failure(let error):
+                throw error
+            }
+        }
+    }
+
     // MARK: - Test Input
 
     struct TestInput {
@@ -56,9 +72,13 @@ final class SignInViewModelTests {
         let mockSignInUseCase = MockSignInUseCase()
         mockSignInUseCase.executeResult = .success(())
         
+        let mockCheckConnectionUseCase = MockCheckConnectionUseCase()
+        mockCheckConnectionUseCase.executeResult = .success(false)
+        
         let expectedOpponentCode = "12345"
         let viewModel = SignInViewModel(
             signInUseCase: mockSignInUseCase,
+            checkConnectionUseCase: mockCheckConnectionUseCase,
             opponentCode: expectedOpponentCode
         )
         
@@ -117,8 +137,11 @@ final class SignInViewModelTests {
         }
         mockSignInUseCase.executeResult = .failure(TestError())
         
+        let mockCheckConnectionUseCase = MockCheckConnectionUseCase()
+        
         let viewModel = SignInViewModel(
             signInUseCase: mockSignInUseCase,
+            checkConnectionUseCase: mockCheckConnectionUseCase,
             opponentCode: nil
         )
         

--- a/Damago/DamagoViewModelTests/SignInViewModelTests.swift
+++ b/Damago/DamagoViewModelTests/SignInViewModelTests.swift
@@ -1,0 +1,171 @@
+//
+//  SignInViewModelTests.swift
+//  DamagoViewModelTests
+//
+//  Created by Gemini on 2/4/26.
+//
+
+import Testing
+import Combine
+import Foundation
+@testable import Damago
+
+@MainActor
+final class SignInViewModelTests {
+    private var cancellables = Set<AnyCancellable>()
+
+    // MARK: - Mocks
+
+    @MainActor
+    class MockSignInUseCase: SignInUseCase {
+        var executeCalled = false
+        var executeResult: Result<Void, Error> = .success(())
+        var onExecute: (() -> Void)?
+        
+        func signIn() async throws {
+            executeCalled = true
+            onExecute?()
+            switch executeResult {
+            case .success:
+                return
+            case .failure(let error):
+                throw error
+            }
+        }
+    }
+
+    // MARK: - Test Input
+
+    struct TestInput {
+        let signInButtonDidTap = PassthroughSubject<Void, Never>()
+        let alertButtonDidTap = PassthroughSubject<Void, Never>()
+        
+        var input: SignInViewModel.Input {
+            SignInViewModel.Input(
+                signInButtonDidTap: signInButtonDidTap.eraseToAnyPublisher(),
+                alertButtonDidTap: alertButtonDidTap.eraseToAnyPublisher()
+            )
+        }
+    }
+
+    // MARK: - Tests
+
+    @Test("로그인 성공 시 UseCase가 실행되고 연결 화면으로 라우팅되어야 한다")
+    func testSignInSuccess() async {
+        // Given
+        let mockSignInUseCase = MockSignInUseCase()
+        mockSignInUseCase.executeResult = .success(())
+        
+        let expectedOpponentCode = "12345"
+        let viewModel = SignInViewModel(
+            signInUseCase: mockSignInUseCase,
+            opponentCode: expectedOpponentCode
+        )
+        
+        let testInput = TestInput()
+        let output = viewModel.transform(testInput.input)
+        
+        // When & Then
+        await confirmation("SignIn UseCase 실행 및 Connection 라우팅 확인", expectedCount: 2) { confirm in
+            var isUseCaseExecuted = false
+            var isRouteUpdated = false
+            
+            let stream = AsyncStream<Void> { continuation in
+                // 1. UseCase 실행
+                mockSignInUseCase.onExecute = {
+                    if !isUseCaseExecuted {
+                        isUseCaseExecuted = true
+                        confirm()
+                        continuation.yield()
+                    }
+                }
+                
+                // 2. Route 변경
+                output.compactMap { $0.route }
+                    .compactMap { $0.value }
+                    .filter {
+                        if case .connection(let code) = $0, code == expectedOpponentCode { return true }
+                        return false
+                    }
+                    .sink { _ in
+                        if !isRouteUpdated {
+                            isRouteUpdated = true
+                            confirm()
+                            continuation.yield()
+                        }
+                    }
+                    .store(in: &cancellables)
+            }
+            var iterator = stream.makeAsyncIterator()
+            
+            testInput.signInButtonDidTap.send(())
+            
+            while !isUseCaseExecuted || !isRouteUpdated {
+                await iterator.next()
+            }
+        }
+        
+        #expect(mockSignInUseCase.executeCalled)
+    }
+
+    @Test("로그인 실패 시 에러 알림으로 라우팅되어야 한다")
+    func testSignInFailure() async {
+        // Given
+        let mockSignInUseCase = MockSignInUseCase()
+        struct TestError: Error, LocalizedError {
+            var errorDescription: String? { "로그인 실패" }
+        }
+        mockSignInUseCase.executeResult = .failure(TestError())
+        
+        let viewModel = SignInViewModel(
+            signInUseCase: mockSignInUseCase,
+            opponentCode: nil
+        )
+        
+        let testInput = TestInput()
+        let output = viewModel.transform(testInput.input)
+        
+        // When & Then
+        await confirmation("SignIn UseCase 실행 및 Alert 라우팅 확인", expectedCount: 2) { confirm in
+            // 상태 플래그
+            var isUseCaseExecuted = false
+            var isRouteUpdated = false
+            
+            let stream = AsyncStream<Void> { continuation in
+                // 1. UseCase 실행
+                mockSignInUseCase.onExecute = {
+                    if !isUseCaseExecuted {
+                        isUseCaseExecuted = true
+                        confirm()
+                        continuation.yield()
+                    }
+                }
+                
+                // 2. Route 변경
+                output.compactMap { $0.route }
+                    .compactMap { $0.value }
+                    .filter {
+                        if case .alert = $0 { return true }
+                        return false
+                    }
+                    .sink { _ in
+                        if !isRouteUpdated {
+                            isRouteUpdated = true
+                            confirm()
+                            continuation.yield()
+                        }
+                    }
+                    .store(in: &cancellables)
+            }
+            var iterator = stream.makeAsyncIterator()
+            
+            testInput.signInButtonDidTap.send(())
+            
+            while !isUseCaseExecuted || !isRouteUpdated {
+                await iterator.next()
+            }
+        }
+        
+        #expect(mockSignInUseCase.executeCalled)
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)를 적어주세요. 해당 이슈가 존재하지 않으면 생략 가능합니다.-->
- resolves #290

## 🥑 작업 요약
<!-- 이번 PR에서 작업한 내용을 간략하게 설명해주세요.-->
- `SignInViewModel`에 대한 Swift Testing 기반의 단위 테스트 작성

## 🛠️ 작업 내용
<!-- 어떻게 보다는 '왜' 이렇게 수정했는지, 의도를 중심으로 작성해주세요.
- 개발 과정에서 발생한 문제와 해결 방법, 대안 등을 정리하면 좋습니다.-->

### `SignInViewModelTests` 작성
- **비동기 테스트 안정화:** `Task.yield`나 `sleep`을 사용하는 대신, `AsyncStream`과 `iterator.next()`를 활용하여 UseCase 실행과 상태 변경을 명시적으로 기다리는 결정론적 테스트 패턴을 적용했습니다.
- `MockSignInUseCase`에 `onExecute` 콜백 함수를 추가하여, 비동기 작업이 시작되는 시점을 테스트 코드에서 정확히 감지할 수 있도록 구현했습니다.

#### 테스트 시나리오
1. **로그인 성공 시나리오**
    - **조건:** 유효한 `opponentCode`가 주어지고 UseCase가 성공을 반환할 때
    - **행위:** 로그인 버튼(`signInButtonDidTap`) 탭
    - **검증:** `SignInUseCase`가 정확히 실행되었는지 확인하고, 최종적으로 `opponentCode`를 포함한 `.connection` 화면으로 라우팅되는지 확인
2. **로그인 실패 시나리오**
    - **조건:** UseCase 실행 중 에러가 발생할 때
    - **행위:** 로그인 버튼(`signInButtonDidTap`) 탭
    - **검증:** 에러 메시지를 포함한 `.alert` 화면으로 라우팅되는지 확인 및 UseCase 호출 여부 검증

## 🧪 테스트 방법
<!-- 리뷰어가 변경 사항을 확인할 수 있는 방법을 서술합니다. -->
- cmd + u로 테스트 통과 확인합니다.

## ✅ 체크리스트
- [x] 빌드 및 실행 테스트를 완료했나요?
- [x] 불필요한 주석 및 Print 문을 제거했나요?
- [x] 코딩 컨벤션을 준수했나요?
