### PR TITLE
[#324] 앱 암호화 문서 추가 / FCM 메소드 스위즐링 속성 제거

### DIFF
--- a/Damago/Damago/Resources/Info.plist
+++ b/Damago/Damago/Resources/Info.plist
@@ -2,7 +2,7 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>FirebaseAppDelegateProxyEnabled</key>
+	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>UIUserInterfaceStyle</key>
 	<string>Light</string>


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)를 적어주세요. 해당 이슈가 존재하지 않으면 생략 가능합니다.-->
- resolves #324

## 🥑 작업 요약
`Info.plist` 설정을 수정하여 앱 스토어 심사 준비를 보완하고 설정을 정리하였습니다.

## 🛠️ 작업 내용
- **앱 암호화 선언 추가 (`ITSAppUsesNonExemptEncryption`)**: 
  - 앱 스토어 커넥트에 앱을 업로드할 때마다 물어보는 수출 규정 준수 답변을 자동화하기 위해 `ITSAppUsesNonExemptEncryption`를 `false`로 설정하였습니다. 
  - 이를 통해 별도의 암호화 문서를 제출하지 않고도 심사 절차를 간소화할 수 있습니다.
- **FCM 메소드 스위즐링 속성 제거 (`FirebaseAppDelegateProxyEnabled`)**:
  - 기존에 `false`로 설정되어 있던 FCM delegate 프록시 비활성화 속성을 제거하였습니다. 

## ✅ 체크리스트
- [x] 빌드 및 실행 테스트를 완료했나요?
- [x] 불필요한 주석 및 Print 문을 제거했나요?
- [x] 코딩 컨벤션을 준수했나요?
