### PR TITLE
[#300] 콕찌르기 일일 횟수 제한

### DIFF
--- a/Damago/Damago/Sources/Data/DTOs/Snapshot/UserSnapshotDTO.swift
+++ b/Damago/Damago/Sources/Data/DTOs/Snapshot/UserSnapshotDTO.swift
@@ -15,4 +15,6 @@ struct UserSnapshotDTO: Decodable {
     let useFCM: Bool
     let useLiveActivity: Bool
     let nickname: String?
+    let todayPokeCount: Int?
+    let lastPokeDate: String?
 }

--- a/Damago/Damago/Sources/Domain/UseCase/ObserveGlobalStateUseCase.swift
+++ b/Damago/Damago/Sources/Domain/UseCase/ObserveGlobalStateUseCase.swift
@@ -89,6 +89,7 @@ final class ObserveGlobalStateUseCaseImpl: ObserveGlobalStateUseCase {
                     opponentName: partnerSnapshot?.nickname,
                     useFCM: userSnapshot.useFCM,
                     useLiveActivity: userSnapshot.useLiveActivity,
+                    todayPokeCount: self.calculatePokeCount(userSnapshot: userSnapshot),
                     // coupleSnapshot이 아직 로드되지 않았을 때(prepend(nil) 등) userSnapshot.coupleID로
                     // 폴백하여, 다마고 변경 등으로 스트림이 재생성될 때 잘못된 "연결 해제" 감지를 방지
                     coupleID: coupleSnapshot?.id ?? userSnapshot.coupleID,
@@ -113,5 +114,19 @@ final class ObserveGlobalStateUseCaseImpl: ObserveGlobalStateUseCase {
                 )
             }
             .eraseToAnyPublisher()
+    }
+    
+    private func calculatePokeCount(userSnapshot: UserSnapshotDTO) -> Int {
+        guard let lastDate = userSnapshot.lastPokeDate,
+              let count = userSnapshot.todayPokeCount else {
+            return 0
+        }
+        
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd"
+        formatter.timeZone = TimeZone(identifier: "Asia/Seoul")
+        let today = formatter.string(from: Date())
+        
+        return lastDate == today ? count : 0
     }
 }

--- a/Damago/Damago/Sources/Presentation/Features/Home/HomeView.swift
+++ b/Damago/Damago/Sources/Presentation/Features/Home/HomeView.swift
@@ -263,4 +263,16 @@ extension HomeView {
         let imageName = isHungry ? "\(damagoType.rawValue)Hungry" : "\(damagoType.rawValue)Base"
         damagoView.animate(spriteSheetName: imageName)
     }
+    
+    func updatePokeButton(todayCount: Int) {
+        var config = pokeButton.configuration ?? UIButton.Configuration.plain()
+        let remaining = max(0, 5 - todayCount)
+        
+        var container = AttributeContainer()
+        container.font = .body3
+        container.foregroundColor = .textSecondary
+        config.attributedSubtitle = AttributedString("\(remaining)/5", attributes: container)
+        
+        pokeButton.configuration = config
+    }
 }

--- a/Damago/Damago/Sources/Presentation/Features/Home/HomeViewController.swift
+++ b/Damago/Damago/Sources/Presentation/Features/Home/HomeViewController.swift
@@ -188,6 +188,11 @@ final class HomeViewController: UIViewController {
             .store(in: &cancellables)
 
         output
+            .mapForUI { $0.todayPokeCount }
+            .sink { [weak self] in self?.mainView.updatePokeButton(todayCount: $0) }
+            .store(in: &cancellables)
+
+        output
             .mapForUI { ExperienceBar.State(level: $0.level, currentExp: $0.currentExp, maxExp: $0.maxExp) }
             .sink { [weak self] in self?.mainView.expBar.update(with: $0) }
             .store(in: &cancellables)

--- a/Damago/Damago/Sources/Presentation/Features/Home/HomeViewModel.swift
+++ b/Damago/Damago/Sources/Presentation/Features/Home/HomeViewModel.swift
@@ -34,9 +34,10 @@ final class HomeViewModel: ViewModel {
         var foodCount = 0
         var lastFedAt: Date?
         var ownedDamagos: [DamagoType: Int] = [:]
+        var todayPokeCount = 0
 
         var isFeedButtonEnabled: Bool { foodCount > 0 && !isFeeding }
-        var isPokeButtonEnabled: Bool { true }
+        var isPokeButtonEnabled: Bool { todayPokeCount < 5 }
         var route: Pulse<Route>?
     }
 
@@ -242,6 +243,11 @@ final class HomeViewModel: ViewModel {
                     self?.state.dDay = 0
                 }
             }
+            .store(in: &cancellables)
+
+        globalStore.globalState
+            .map { $0.todayPokeCount }
+            .sink { [weak self] in self?.state.todayPokeCount = $0 }
             .store(in: &cancellables)
     }
 }

--- a/Damago/Damago/Sources/Presentation/Shared/Store/GlobalState.swift
+++ b/Damago/Damago/Sources/Presentation/Shared/Store/GlobalState.swift
@@ -13,6 +13,7 @@ struct GlobalState: Equatable {
     let opponentName: String?
     let useFCM: Bool
     let useLiveActivity: Bool
+    let todayPokeCount: Int
     
     // MARK: - Couple Content
     let coupleID: String?
@@ -40,6 +41,7 @@ struct GlobalState: Equatable {
         opponentName: nil,
         useFCM: false,
         useLiveActivity: false,
+        todayPokeCount: 0,
         coupleID: nil,
         totalCoin: nil,
         foodCount: nil,


### PR DESCRIPTION
## 📌 관련 이슈
- resolves #300

## 🥑 작업 요약
- 콕 찌르기 기능에 일일 5회 제한을 적용
- 환경 전환 시 발생하던 FCM 토큰 동기화 이슈를 해결했습니다.

## 🛠️ 작업 내용
### 1. 콕 찌르기 5회 제한 (Backend & Domain)
- **Backend:** `push_service.py`에서 KST 기준 날짜 확인(자정 초기화) 및 Firestore 트랜잭션을 통한 `todayPokeCount` 관리 로직을 추가했습니다.
- **Client Domain:** `UserSnapshotDTO`와 `GlobalState`에 관련 필드를 추가하고, `ObserveGlobalStateUseCase`에서 로컬 시간 기준 날짜 초기화 로직을 구현했습니다.

### 2. FCM 토큰 동기화 이슈 해결
- `AppDelegate`에서 앱 실행 시마다 현재 FCM 토큰을 강제로 조회하고 서버에 업데이트하도록 수정하여, 빌드 환경 전환(Debug <-> Release) 시 푸시가 오지 않던 문제를 해결했습니다.

## 📸 스크린샷 (UI 변경 시)

https://github.com/user-attachments/assets/60a71033-e60c-495b-9e54-71c8d837085c


## 🧪 테스트 방법
- 홈 화면 진입 시 콕 찌르기 버튼에 남은 횟수가 정상적으로 표시되는지 확인합니다.
- 콕 찌르기 수행 시 숫자가 실시간으로 차감되는지 확인합니다.

## ✅ 체크리스트
- [x] 빌드 및 실행 테스트를 완료했나요?
- [x] 불필요한 주석 및 Print 문을 제거했나요?
- [x] 코딩 컨벤션을 준수했나요?