### PR TITLE
[#340] CAAnimation을 통한 GachaAnimationView 애니메이션 최적화 및 성능 분석

### DIFF
--- a/Damago/Damago/Sources/Presentation/Features/Collection/CollectionViewModel.swift
+++ b/Damago/Damago/Sources/Presentation/Features/Collection/CollectionViewModel.swift
@@ -90,8 +90,8 @@ final class CollectionViewModel: ViewModel {
     private func changeDamago() {
         guard let selectedDamago = state.selectedDamago else { return }
 
+        state.isLoading = true
         Task {
-            state.isLoading = true
             defer { state.isLoading = false }
 
             do {

--- a/Damago/Damago/Sources/Presentation/Features/Collection/Store/GachaAnimationView.swift
+++ b/Damago/Damago/Sources/Presentation/Features/Collection/Store/GachaAnimationView.swift
@@ -79,6 +79,7 @@ struct GachaAnimationView: View {
                 
                 Image(machineImageName)
                     .resizable()
+                    .interpolation(.medium)
                     .scaledToFit()
                     .frame(width: machineWidth, height: machineHeight)
                     .offset(x: shakeOffset)
@@ -87,6 +88,7 @@ struct GachaAnimationView: View {
                 if showCapsule {
                     Image(capsuleImageName)
                         .resizable()
+                        .interpolation(.medium)
                         .scaledToFit()
                         .frame(width: 40, height: 40)
                         .scaleEffect(capsuleScale)
@@ -112,6 +114,7 @@ struct GachaAnimationView: View {
                     .padding(.trailing, 20)
                 }
             }
+            .compositingGroup()
         }
         .background(Color.clear)
         .ignoresSafeArea()

--- a/Damago/Damago/Sources/Presentation/Features/Collection/Store/GachaAnimationView.swift
+++ b/Damago/Damago/Sources/Presentation/Features/Collection/Store/GachaAnimationView.swift
@@ -6,8 +6,11 @@
 //
 
 import SwiftUI
+import os
 
 struct GachaAnimationView: View {
+    private static let signposter = OSSignposter(subsystem: "com.damago.app", category: "GachaAnimation")
+    
     private enum Constants {
         enum AnimationDuration {
             static let shakeCycle: Double = 0.05
@@ -138,6 +141,9 @@ struct GachaAnimationView: View {
     
     @MainActor
     private func play() async {
+        let state = Self.signposter.beginInterval("TotalAnimation")
+        defer { Self.signposter.endInterval("TotalAnimation", state) }
+
         await performShakeMachine()
         if isSkipped { return }
         
@@ -155,6 +161,9 @@ struct GachaAnimationView: View {
     
     @MainActor
     private func performShakeMachine() async {
+        let state = Self.signposter.beginInterval("ShakeMachine")
+        defer { Self.signposter.endInterval("ShakeMachine", state) }
+
         phase = .shaking
         let generator = UIImpactFeedbackGenerator(style: .medium)
         
@@ -177,6 +186,9 @@ struct GachaAnimationView: View {
     
     @MainActor
     private func performEjectCapsule() async {
+        let state = Self.signposter.beginInterval("EjectCapsule")
+        defer { Self.signposter.endInterval("EjectCapsule", state) }
+
         phase = .ejecting
         withAnimation(.spring(response: 0.8, dampingFraction: 0.6)) {
             capsuleOffset = Constants.Animation.capsuleEjectOffset
@@ -187,6 +199,9 @@ struct GachaAnimationView: View {
     
     @MainActor
     private func performWobbleCapsule() async {
+        let state = Self.signposter.beginInterval("WobbleCapsule")
+        defer { Self.signposter.endInterval("WobbleCapsule", state) }
+
         phase = .wobbling
         for _ in 0..<Constants.Animation.wobbleCount {
             if isSkipped { return }
@@ -205,6 +220,9 @@ struct GachaAnimationView: View {
     
     @MainActor
     private func performRevealResult() async {
+        let state = Self.signposter.beginInterval("RevealResult")
+        defer { Self.signposter.endInterval("RevealResult", state) }
+
         phase = .revealing
         
         withAnimation(.easeOut(duration: Constants.AnimationDuration.reveal)) {

--- a/Damago/Damago/Sources/Presentation/Features/Collection/Store/StoreViewController.swift
+++ b/Damago/Damago/Sources/Presentation/Features/Collection/Store/StoreViewController.swift
@@ -151,6 +151,10 @@ final class StoreViewController: UIViewController {
         UIView.animate(withDuration: 0.3) {
             self.mainView.resultView.alpha = 1.0
         }
+        
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) { [weak self] in
+            self?.hideResultOverlay()
+        }
     }
     
     private func hideResultOverlay() {

--- a/Damago/Damago/Sources/Presentation/Features/Collection/Store/StoreViewController.swift
+++ b/Damago/Damago/Sources/Presentation/Features/Collection/Store/StoreViewController.swift
@@ -53,7 +53,7 @@ final class StoreViewController: UIViewController {
             .compactMapForUI { $0.drawResult }
             .receive(on: DispatchQueue.main)
             .sink { [weak self] result in
-                guard let self = self else { return }
+                guard let self else { return }
                 self.triggerGachaAnimation(result: result)
             }
             .store(in: &cancellables)
@@ -112,37 +112,29 @@ final class StoreViewController: UIViewController {
         mainView.drawButton.isEnabled = false
         mainView.exitButton.isHidden = true
         
-        let animationView = GachaAnimationView { [weak self] in
+        let animationView = GachaAnimationView()
+        animationView.onFinish = { [weak self] in
             guard let self else { return }
             
             self.showResultOverlay(result: result)
             
-            if let hostingVC = self.children.first(where: { $0 is UIHostingController<GachaAnimationView> }) {
-                hostingVC.willMove(toParent: nil)
-                hostingVC.view.removeFromSuperview()
-                hostingVC.removeFromParent()
-            }
+            animationView.removeFromSuperview()
             
             self.mainView.machineImageView.isHidden = false
             self.mainView.drawButton.isEnabled = self.viewModel.state.isDrawButtonEnabled
             self.mainView.exitButton.isHidden = false
         }
         
-        let hostingController = UIHostingController(rootView: animationView)
-        hostingController.view.backgroundColor = .clear
-        
-        addChild(hostingController)
-        mainView.addSubview(hostingController.view)
-        
-        hostingController.view.translatesAutoresizingMaskIntoConstraints = false
+        mainView.addSubview(animationView)
+        animationView.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
-            hostingController.view.topAnchor.constraint(equalTo: mainView.topAnchor),
-            hostingController.view.leadingAnchor.constraint(equalTo: mainView.leadingAnchor),
-            hostingController.view.trailingAnchor.constraint(equalTo: mainView.trailingAnchor),
-            hostingController.view.bottomAnchor.constraint(equalTo: mainView.bottomAnchor)
+            animationView.topAnchor.constraint(equalTo: mainView.topAnchor),
+            animationView.leadingAnchor.constraint(equalTo: mainView.leadingAnchor),
+            animationView.trailingAnchor.constraint(equalTo: mainView.trailingAnchor),
+            animationView.bottomAnchor.constraint(equalTo: mainView.bottomAnchor)
         ])
         
-        hostingController.didMove(toParent: self)
+        animationView.startAnimation()
     }
     
     private func showResultOverlay(result: DrawResult) {

--- a/Damago/Damago/Sources/Presentation/Features/Collection/Store/StoreViewController.swift
+++ b/Damago/Damago/Sources/Presentation/Features/Collection/Store/StoreViewController.swift
@@ -143,10 +143,6 @@ final class StoreViewController: UIViewController {
         UIView.animate(withDuration: 0.3) {
             self.mainView.resultView.alpha = 1.0
         }
-        
-        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) { [weak self] in
-            self?.hideResultOverlay()
-        }
     }
     
     private func hideResultOverlay() {

--- a/Damago/Damago/Sources/Presentation/Features/Collection/Store/StoreViewModel.swift
+++ b/Damago/Damago/Sources/Presentation/Features/Collection/Store/StoreViewModel.swift
@@ -10,7 +10,7 @@ import Foundation
 
 final class StoreViewModel: ViewModel {
     enum StorePolicy {
-        static let drawCost = 100
+        static let drawCost = 0
     }
     
     enum StoreStrings {
@@ -78,20 +78,27 @@ final class StoreViewModel: ViewModel {
     }
     
     private func tryDraw() {
-        guard state.coinAmount >= StorePolicy.drawCost else {
-            state.error = Pulse(.notEnoughCoin)
-            return
-        }
+//        guard state.coinAmount >= StorePolicy.drawCost else {
+//            state.error = Pulse(.notEnoughCoin)
+//            return
+//        }
         
         state.isLoading = true
+        defer { state.isLoading = false }
         
         Task {
-            do {
-                state.drawResult = try await createDamagoUseCase.execute()
-            } catch {
-                state.error = Pulse(.creationFailed)
+//            do {
+//                state.drawResult = try await createDamagoUseCase.execute()
+//            } catch {
+//                state.error = Pulse(.creationFailed)
+//            }
+            for _ in 0..<10 {
+                state.drawResult = nil
+                try? await Task.sleep(for: .milliseconds(50))
+                
+                state.drawResult = DrawResult(damagoType: .basicBlack, isNew: true)
+                try? await Task.sleep(for: .seconds(6))
             }
-            state.isLoading = false
         }
     }
 }

--- a/Damago/Damago/Sources/Presentation/Features/Collection/Store/StoreViewModel.swift
+++ b/Damago/Damago/Sources/Presentation/Features/Collection/Store/StoreViewModel.swift
@@ -10,7 +10,7 @@ import Foundation
 
 final class StoreViewModel: ViewModel {
     enum StorePolicy {
-        static let drawCost = 0
+        static let drawCost = 100
     }
     
     enum StoreStrings {
@@ -78,26 +78,19 @@ final class StoreViewModel: ViewModel {
     }
     
     private func tryDraw() {
-//        guard state.coinAmount >= StorePolicy.drawCost else {
-//            state.error = Pulse(.notEnoughCoin)
-//            return
-//        }
+        guard state.coinAmount >= StorePolicy.drawCost else {
+            state.error = Pulse(.notEnoughCoin)
+            return
+        }
         
         state.isLoading = true
         defer { state.isLoading = false }
         
         Task {
-//            do {
-//                state.drawResult = try await createDamagoUseCase.execute()
-//            } catch {
-//                state.error = Pulse(.creationFailed)
-//            }
-            for _ in 0..<10 {
-                state.drawResult = nil
-                try? await Task.sleep(for: .milliseconds(50))
-                
-                state.drawResult = DrawResult(damagoType: .basicBlack, isNew: true)
-                try? await Task.sleep(for: .seconds(6))
+            do {
+                state.drawResult = try await createDamagoUseCase.execute()
+            } catch {
+                state.error = Pulse(.creationFailed)
             }
         }
     }

--- a/Damago/Damago/Sources/Presentation/Features/Collection/Store/StoreViewModel.swift
+++ b/Damago/Damago/Sources/Presentation/Features/Collection/Store/StoreViewModel.swift
@@ -84,9 +84,8 @@ final class StoreViewModel: ViewModel {
         }
         
         state.isLoading = true
-        defer { state.isLoading = false }
-        
         Task {
+            defer { state.isLoading = false }
             do {
                 state.drawResult = try await createDamagoUseCase.execute()
             } catch {

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -4,28 +4,25 @@ platform :ios do
   desc "Run tests for Debug and Build verification for Release"
   lane :test do
     # ----------------------------------------------------------------
-    # 1. 공통 설정 및 시뮬레이터 사전 부팅
+    # 1. 공통 타겟 설정
     # ----------------------------------------------------------------
     device_name = "iPhone 17 Pro"
+    os_version = "26.2"
     
-    # xcodebuild가 시뮬레이터를 켜느라 멈추는 것을 방지하기 위해 미리 부팅
-    puts "📱 Booting #{device_name}..."
-    sh("xcrun simctl boot '#{device_name}' || true") 
-    sh("xcrun simctl bootstatus '#{device_name}'")
+    # OS 버전까지 포함된 완전한 destination 문자열
+    target_destination = "platform=iOS Simulator,name=#{device_name},OS=#{os_version}"
 
     # ----------------------------------------------------------------
-    # 2. Debug 모드: 단위 테스트(Test) 수행
+    # 2. Debug 모드: 단위 테스트 수행
     # ----------------------------------------------------------------
     puts "🚀 Testing Debug build..."
     scan(
       project: "./Damago/Damago.xcodeproj",
       scheme: "Damago",
       configuration: "Debug",
-      device: device_name,
+      device: "iPhone 17 Pro (26.2)", 
       clean: false,
-      
-      # [핵심] 30분 타임아웃 방지를 위해 병렬 테스트 비활성화
-      xcargs: "-skipPackagePluginValidation -parallel-testing-enabled NO ARCHS=arm64"
+      xcargs: "-skipPackagePluginValidation -parallel-testing-enabled NO"
     )
 
     # ----------------------------------------------------------------
@@ -35,18 +32,14 @@ platform :ios do
     if current_branch == "main" || ENV["GITHUB_REF_NAME"] == "main"
       puts "📦 Building Release build (Skip Tests)..."
       
-      # scan(테스트) 대신 xcodebuild(빌드)만 실행
-      # Release 모드에서 컴파일 에러가 없는지만 빠르게 확인합니다.
       xcodebuild(
         project: "./Damago/Damago.xcodeproj",
         scheme: "Damago",
         configuration: "Release",
         clean: false,
-        build: true,      # 테스트 없이 빌드 액션만 수행
-        analyze: false,   # 정적 분석 생략 (속도 향상)
-        
-        # CI에 인증서 세팅이 없어도 빌드가 터지지 않도록 '시뮬레이터'용으로 빌드
-        destination: "platform=iOS Simulator,name=#{device_name}",
+        build: true,      
+        analyze: false,   
+        destination: target_destination,
         xcargs: "-skipPackagePluginValidation RUN_CLANG_STATIC_ANALYZER=NO ARCHS=arm64"
       )
     end


### PR DESCRIPTION
## 📌 관련 이슈
- #340

## 🥑 작업 요약
- SwiftUI 기반의 가챠 애니메이션을 순수 UIKit 및 Core Animation으로 리팩토링하여 성능 지표를 극대화
- `withCheckedContinuation`을 도입하여 콜백 기반의 CAAnimation을 `async/await` 구조로 현대화
- Instruments 측정을 통해 과도한 CPU Commits의 밀집 해결 및 GPU Hitch 감소를 증명함.

## 🛠️ 작업 내용
### 배경
기존 SwiftUI + `Task.sleep` 루프 방식은 매 스텝마다 메인 스레드 커밋을 유발하여 10회 애니메이션 반복 시 3,000회 이상의 과도한 커밋 밀도와 잦은 GPU Hitch 10회 를 발생

### 시도
렌더링 파이프라인에 따라 CPU 에서 과도한 Commits 이 Hitch 를 유발할 수 있음. 따라서, GPU 계층에서 애니메이션을 진행할 수 있도록 CATransaction 을 통해 Commit 전달
- `CAKeyframeAnimation` 및 `CASpringAnimation`을 사용하여 애니메이션 연산을 **Render Server**로 이관하여 메인 스레드 부하를 최소화
- `withCheckedContinuation`을 활용해 비동기 애니메이션 시퀀스(Shake -> Eject -> Wobble -> Reveal)를 선형적 구조로 개선
- `Skip` 기능을 레이어 애니메이션 중단 로직과 안전한 상태 관리 변수(`isFinished`, `isSkipped`)를 통해 구현

### 성과  
- **Commit Density**: 커밋 밀도를 획기적으로 낮추어 CPU가 비즈니스 로직에 집중할 수 있는 환경 확보.
- **GPU Hitch**: 10회 연속 애니메이션 중 GPU Rendering Hitch를 단 1회로 억제 (기존 대비 약 90% 개선).

## 📸 스크린샷 (성능 비교)

### 1. Core Animation Commits (Density)
| AS-IS (SwiftUI Loop) | TO-BE (CAAnimation) |
| :--: | :--: |
| <img width="1020" height="732" alt="개선 전 Commits" src="https://github.com/user-attachments/assets/c0e51275-0406-48f9-ae48-1cc4998a3320" /><br/>*빽빽한 Green Wall 발생* | <img width="1022" height="758" alt="CAAnimation Commits" src="https://github.com/user-attachments/assets/a0eb30db-e2fb-47e7-9dfd-b4fc04ce170f" /><br/>*커밋 빈도 대폭 감소* |

### 2. GPU Rendering Hitch
| AS-IS (SwiftUI Loop) | TO-BE (CAAnimation) |
| :--: | :--: |
| <img width="1020" height="732" alt="개선 전 GPU Hitch" src="https://github.com/user-attachments/assets/5758ce82-5eb3-4846-8c06-997f385050fb" /><br/>*잦은 프레임 드랍 발생* | <img width="1022" height="758" alt="CAAnimation GPU Hitch" src="https://github.com/user-attachments/assets/933c0243-70b2-4d78-9884-26799e405610" /><br/>*10회 중 1회로 최소화* |

### 성능 측정 간 스크린 녹화
#### SwiftUI Loop
https://github.com/user-attachments/assets/d37f4029-96e0-464e-84ce-145b90f970e5

#### CAAnimation
https://github.com/user-attachments/assets/7ec04740-4b56-49dc-abc5-dd7021e60433

## 🧪 성능 측정 환경
- **기기**: iPhone 16 Pro (실기기)
- **OS**: iOS 26.2
- **방법**: `Instruments` (Animation Hitches, Core Animation Commits, Frame Lifetimes, Points of Interest) 프로파일을 사용하여 상점에서 뽑기 버튼 1회 클릭 시 발생하는 10회 연속 애니메이션 수동 측정.
- **환경**: 네트워크 통신 코드를 제거한 `StoreViewModel` 코드 환경에서 수행

## 💬 리뷰 요구사항 (Optional)
- **참고**: 본 실험 결과는 `KeyframeAnimator`를 사용하는 성능 비교 대조군으로 사용됩니다.

## ✅ 체크리스트
- [x] 빌드 및 실행 테스트를 완료했나요?
- [x] 불필요한 주석 및 Print 문을 제거했나요?
- [x] 코딩 컨벤션을 준수했나요?
