### PR TITLE
[#340] GachaAnimionView 성능 분석을 통한 Animation Hitch 개선

### DIFF
--- a/Damago/Damago/Sources/Presentation/Features/Collection/Store/GachaAnimationView.swift
+++ b/Damago/Damago/Sources/Presentation/Features/Collection/Store/GachaAnimationView.swift
@@ -79,6 +79,7 @@ struct GachaAnimationView: View {
                 
                 Image(machineImageName)
                     .resizable()
+                    .interpolation(.medium)
                     .scaledToFit()
                     .frame(width: machineWidth, height: machineHeight)
                     .offset(x: shakeOffset)
@@ -87,6 +88,7 @@ struct GachaAnimationView: View {
                 if showCapsule {
                     Image(capsuleImageName)
                         .resizable()
+                        .interpolation(.medium)
                         .scaledToFit()
                         .frame(width: 40, height: 40)
                         .scaleEffect(capsuleScale)
@@ -112,6 +114,7 @@ struct GachaAnimationView: View {
                     .padding(.trailing, 20)
                 }
             }
+            .compositingGroup()
         }
         .background(Color.clear)
         .ignoresSafeArea()

--- a/Damago/Damago/Sources/Presentation/Features/Collection/Store/GachaAnimationView.swift
+++ b/Damago/Damago/Sources/Presentation/Features/Collection/Store/GachaAnimationView.swift
@@ -6,11 +6,8 @@
 //
 
 import SwiftUI
-import os
 
 struct GachaAnimationView: View {
-    private static let signposter = OSSignposter(subsystem: "com.damago.app", category: "GachaAnimation")
-    
     private enum Constants {
         enum AnimationDuration {
             static let total: Double = 4.5
@@ -164,24 +161,14 @@ struct GachaAnimationView: View {
         
         guard animationTrigger else { return }
         
-        let state = Self.signposter.beginInterval("TotalAnimation")
+        try? await Task.sleep(for: .seconds(Constants.AnimationDuration.total))
         
-        do {
-            try await Task.sleep(for: .seconds(Constants.AnimationDuration.total))
-            Self.signposter.endInterval("TotalAnimation", state)
-            finishAnimation()
-        } catch {
-            Self.signposter.endInterval("TotalAnimation", state, "Cancelled by Skip")
-        }
+        finishAnimation()
     }
     
     private func finishAnimation() {
         guard !isFinished else { return }
         isFinished = true
-        if let state = _totalAnimationState {
-            Self.signposter.endInterval("TotalAnimation", state)
-            _totalAnimationState = nil
-        }
         onFinish?()
     }
     

--- a/Damago/Damago/Sources/Presentation/Features/Collection/Store/GachaAnimationView.swift
+++ b/Damago/Damago/Sources/Presentation/Features/Collection/Store/GachaAnimationView.swift
@@ -6,8 +6,11 @@
 //
 
 import SwiftUI
+import os
 
 struct GachaAnimationView: View {
+    private static let signposter = OSSignposter(subsystem: "com.damago.app", category: "GachaAnimation")
+    
     private enum Constants {
         enum AnimationDuration {
             static let shakeCycle: Double = 0.05
@@ -138,6 +141,9 @@ struct GachaAnimationView: View {
     
     @MainActor
     private func play() async {
+        let state = Self.signposter.beginInterval("TotalAnimation")
+        defer { Self.signposter.endInterval("TotalAnimation", state) }
+
         await performShakeMachine()
         if isSkipped { return }
         
@@ -155,6 +161,9 @@ struct GachaAnimationView: View {
     
     @MainActor
     private func performShakeMachine() async {
+        let state = Self.signposter.beginInterval("ShakeMachine")
+        defer { Self.signposter.endInterval("ShakeMachine", state) }
+
         phase = .shaking
         let generator = UIImpactFeedbackGenerator(style: .medium)
         
@@ -177,6 +186,9 @@ struct GachaAnimationView: View {
     
     @MainActor
     private func performEjectCapsule() async {
+        let state = Self.signposter.beginInterval("EjectCapsule")
+        defer { Self.signposter.endInterval("EjectCapsule", state) }
+
         phase = .ejecting
         withAnimation(.spring(response: 0.8, dampingFraction: 0.6)) {
             capsuleOffset = Constants.Animation.capsuleEjectOffset
@@ -187,6 +199,9 @@ struct GachaAnimationView: View {
     
     @MainActor
     private func performWobbleCapsule() async {
+        let state = Self.signposter.beginInterval("WobbleCapsule")
+        defer { Self.signposter.endInterval("WobbleCapsule", state) }
+
         phase = .wobbling
         for _ in 0..<Constants.Animation.wobbleCount {
             if isSkipped { return }
@@ -205,6 +220,9 @@ struct GachaAnimationView: View {
     
     @MainActor
     private func performRevealResult() async {
+        let state = Self.signposter.beginInterval("RevealResult")
+        defer { Self.signposter.endInterval("RevealResult", state) }
+
         phase = .revealing
         
         withAnimation(.easeOut(duration: Constants.AnimationDuration.reveal)) {

--- a/Damago/Damago/Sources/Presentation/Features/Collection/Store/StoreViewController.swift
+++ b/Damago/Damago/Sources/Presentation/Features/Collection/Store/StoreViewController.swift
@@ -112,29 +112,37 @@ final class StoreViewController: UIViewController {
         mainView.drawButton.isEnabled = false
         mainView.exitButton.isHidden = true
         
-        let animationView = GachaAnimationView()
-        animationView.onFinish = { [weak self] in
+        let animationView = GachaAnimationView { [weak self] in
             guard let self else { return }
             
             self.showResultOverlay(result: result)
             
-            animationView.removeFromSuperview()
+            if let hostingVC = self.children.first(where: { $0 is UIHostingController<GachaAnimationView> }) {
+                hostingVC.willMove(toParent: nil)
+                hostingVC.view.removeFromSuperview()
+                hostingVC.removeFromParent()
+            }
             
             self.mainView.machineImageView.isHidden = false
             self.mainView.drawButton.isEnabled = self.viewModel.state.isDrawButtonEnabled
             self.mainView.exitButton.isHidden = false
         }
         
-        mainView.addSubview(animationView)
-        animationView.translatesAutoresizingMaskIntoConstraints = false
+        let hostingController = UIHostingController(rootView: animationView)
+        hostingController.view.backgroundColor = .clear
+        
+        addChild(hostingController)
+        mainView.addSubview(hostingController.view)
+        
+        hostingController.view.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
-            animationView.topAnchor.constraint(equalTo: mainView.topAnchor),
-            animationView.leadingAnchor.constraint(equalTo: mainView.leadingAnchor),
-            animationView.trailingAnchor.constraint(equalTo: mainView.trailingAnchor),
-            animationView.bottomAnchor.constraint(equalTo: mainView.bottomAnchor)
+            hostingController.view.topAnchor.constraint(equalTo: mainView.topAnchor),
+            hostingController.view.leadingAnchor.constraint(equalTo: mainView.leadingAnchor),
+            hostingController.view.trailingAnchor.constraint(equalTo: mainView.trailingAnchor),
+            hostingController.view.bottomAnchor.constraint(equalTo: mainView.bottomAnchor)
         ])
         
-        animationView.startAnimation()
+        hostingController.didMove(toParent: self)
     }
     
     private func showResultOverlay(result: DrawResult) {

--- a/Damago/Damago/Sources/Presentation/Features/Collection/Store/StoreViewController.swift
+++ b/Damago/Damago/Sources/Presentation/Features/Collection/Store/StoreViewController.swift
@@ -151,6 +151,10 @@ final class StoreViewController: UIViewController {
         UIView.animate(withDuration: 0.3) {
             self.mainView.resultView.alpha = 1.0
         }
+        
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) { [weak self] in
+            self?.hideResultOverlay()
+        }
     }
     
     private func hideResultOverlay() {

--- a/Damago/Damago/Sources/Presentation/Features/Collection/Store/StoreViewController.swift
+++ b/Damago/Damago/Sources/Presentation/Features/Collection/Store/StoreViewController.swift
@@ -151,10 +151,6 @@ final class StoreViewController: UIViewController {
         UIView.animate(withDuration: 0.3) {
             self.mainView.resultView.alpha = 1.0
         }
-        
-        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) { [weak self] in
-            self?.hideResultOverlay()
-        }
     }
     
     private func hideResultOverlay() {

--- a/Damago/Damago/Sources/Presentation/Features/Collection/Store/StoreViewController.swift
+++ b/Damago/Damago/Sources/Presentation/Features/Collection/Store/StoreViewController.swift
@@ -53,7 +53,7 @@ final class StoreViewController: UIViewController {
             .compactMapForUI { $0.drawResult }
             .receive(on: DispatchQueue.main)
             .sink { [weak self] result in
-                guard let self = self else { return }
+                guard let self else { return }
                 self.triggerGachaAnimation(result: result)
             }
             .store(in: &cancellables)
@@ -112,37 +112,29 @@ final class StoreViewController: UIViewController {
         mainView.drawButton.isEnabled = false
         mainView.exitButton.isHidden = true
         
-        let animationView = GachaAnimationView { [weak self] in
+        let animationView = GachaAnimationView()
+        animationView.onFinish = { [weak self] in
             guard let self else { return }
             
             self.showResultOverlay(result: result)
             
-            if let hostingVC = self.children.first(where: { $0 is UIHostingController<GachaAnimationView> }) {
-                hostingVC.willMove(toParent: nil)
-                hostingVC.view.removeFromSuperview()
-                hostingVC.removeFromParent()
-            }
+            animationView.removeFromSuperview()
             
             self.mainView.machineImageView.isHidden = false
             self.mainView.drawButton.isEnabled = self.viewModel.state.isDrawButtonEnabled
             self.mainView.exitButton.isHidden = false
         }
         
-        let hostingController = UIHostingController(rootView: animationView)
-        hostingController.view.backgroundColor = .clear
-        
-        addChild(hostingController)
-        mainView.addSubview(hostingController.view)
-        
-        hostingController.view.translatesAutoresizingMaskIntoConstraints = false
+        mainView.addSubview(animationView)
+        animationView.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
-            hostingController.view.topAnchor.constraint(equalTo: mainView.topAnchor),
-            hostingController.view.leadingAnchor.constraint(equalTo: mainView.leadingAnchor),
-            hostingController.view.trailingAnchor.constraint(equalTo: mainView.trailingAnchor),
-            hostingController.view.bottomAnchor.constraint(equalTo: mainView.bottomAnchor)
+            animationView.topAnchor.constraint(equalTo: mainView.topAnchor),
+            animationView.leadingAnchor.constraint(equalTo: mainView.leadingAnchor),
+            animationView.trailingAnchor.constraint(equalTo: mainView.trailingAnchor),
+            animationView.bottomAnchor.constraint(equalTo: mainView.bottomAnchor)
         ])
         
-        hostingController.didMove(toParent: self)
+        animationView.startAnimation()
     }
     
     private func showResultOverlay(result: DrawResult) {

--- a/Damago/Damago/Sources/Presentation/Features/Collection/Store/StoreViewModel.swift
+++ b/Damago/Damago/Sources/Presentation/Features/Collection/Store/StoreViewModel.swift
@@ -10,7 +10,7 @@ import Foundation
 
 final class StoreViewModel: ViewModel {
     enum StorePolicy {
-        static let drawCost = 0
+        static let drawCost = 100
     }
     
     enum StoreStrings {
@@ -78,26 +78,19 @@ final class StoreViewModel: ViewModel {
     }
     
     private func tryDraw() {
-//        guard state.coinAmount >= StorePolicy.drawCost else {
-//            state.error = Pulse(.notEnoughCoin)
-//            return
-//        }
+        guard state.coinAmount >= StorePolicy.drawCost else {
+            state.error = Pulse(.notEnoughCoin)
+            return
+        }
         
         state.isLoading = true
         defer { state.isLoading = false }
         
         Task {
-//            do {
-//                state.drawResult = try await createDamagoUseCase.execute()
-//            } catch {
-//                state.error = Pulse(.creationFailed)
-//            }
-            for _ in 0..<10 {
-                state.drawResult = nil
-                try? await Task.sleep(for: .milliseconds(50))
-                
-                state.drawResult = DrawResult(damagoType: .basicBlack, isNew: true)
-                try? await Task.sleep(for: .seconds(6))
+            do {
+                state.drawResult = try await createDamagoUseCase.execute()
+            } catch {
+                state.error = Pulse(.creationFailed)
             }
         }
     }

--- a/Damago/Damago/Sources/Presentation/Features/Collection/Store/StoreViewModel.swift
+++ b/Damago/Damago/Sources/Presentation/Features/Collection/Store/StoreViewModel.swift
@@ -10,7 +10,7 @@ import Foundation
 
 final class StoreViewModel: ViewModel {
     enum StorePolicy {
-        static let drawCost = 100
+        static let drawCost = 0
     }
     
     enum StoreStrings {
@@ -78,21 +78,27 @@ final class StoreViewModel: ViewModel {
     }
     
     private func tryDraw() {
-        guard state.coinAmount >= StorePolicy.drawCost else {
-            state.error = Pulse(.notEnoughCoin)
-            return
-        }
+//        guard state.coinAmount >= StorePolicy.drawCost else {
+//            state.error = Pulse(.notEnoughCoin)
+//            return
+//        }
         
         state.isLoading = true
+        defer { state.isLoading = false }
         
         Task {
-            defer { state.isLoading = false }
-            do {
-                state.drawResult = try await createDamagoUseCase.execute()
-            } catch {
-                state.error = Pulse(.creationFailed)
+//            do {
+//                state.drawResult = try await createDamagoUseCase.execute()
+//            } catch {
+//                state.error = Pulse(.creationFailed)
+//            }
+            for _ in 0..<10 {
+                state.drawResult = nil
+                try? await Task.sleep(for: .milliseconds(50))
+                
+                state.drawResult = DrawResult(damagoType: .basicBlack, isNew: true)
+                try? await Task.sleep(for: .seconds(6))
             }
-            state.isLoading = false
         }
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈
- resolves #340
- 상위 실험 PR: #341 참고

## 🥑 작업 요약
- **문제 상황:** 기존 `Task.sleep` 기반 루프 애니메이션의 비효율적인 렌더링 동기화로 인한 GPU Hitch 발생 및 강제 종료(Skip) 시 상태 동기화의 불안정성.
- **해결 방안:** - iOS 17+ API인 `KeyframeAnimator`를 도입하여 애니메이션 타이밍 제어를 프레임워크에 위임하고 가독성 및 유지보수성 향상.
  - `.task(id:)` 구조적 동시성을 활용해 안전하고 즉각적인 애니메이션 스킵 로직 구현.
  - `compositingGroup` 적용으로 레이어 합성 단계를 최적화하여 렌더링 성능 개선.
- **최종 결과:** 기존 대비 GPU Rendering Hitch를 유의미하게 감소(10회 -> 7회)시켰으며, 팀 차원의 코드 유지보수성과 상태 관리 안정성을 크게 확보함.

## 🛠️ 작업 내용

### 1. 기술적 의사결정: 왜 KeyframeAnimator인가?
실험 PR #341에서 `CAAnimation`을 통한 극한의 하드웨어 가속 성능 최적화를 확인했으나, 팀의 유지보수 비용과 로직의 안정성을 고려하여 최종적으로 `KeyframeAnimator`를 채택했습니다.
- **취소 기능의 안정성 확보**: `CAAnimation`은 중단 시 레이어 계층의 애니메이션을 수동으로 제거하고 프레젠테이션 트리와 모델 트리의 상태를 강제로 동기화해야 하는 명령형 로직의 복잡도가 매우 높습니다. 반면, `KeyframeAnimator`는 `.task(id:)`를 통해 상태(State) 변경만으로 즉각적이고 안전한 취소가 가능합니다.
- **복합 타이밍 제어의 용이성**: `UIViewPropertyAnimator` 또한 대안으로 고려했으나, 여전히 명령형이며, Linear와 Spring 애니메이션이 혼재된 이번 시퀀스 특성상 각 단계의 정밀한 타이밍을 선언적으로 관리하기에는 `KeyframeAnimator`가 압도적으로 유리했습니다.
- **유지보수성 향상**: Apple의 [Unifying animations](https://developer.apple.com/documentation/swiftui/unifying-your-app-s-animations) 가이드에 따르면, 비록 저수준 CA 직접 제어는 불가능하더라도 선언적 UI가 주는 가독성의 이점이 훨씬 큽니다. 결과적으로 성능상으로는 `CAAnimation`이 우위였으나, 누구나 읽고 수정하기 쉬운 선언적 구조를 통해 버그 발생 확률을 낮추는 방향을 선택했습니다.

### 2. 렌더링 최적화 뷰 모디파이어 비교 분석
- **`drawingGroup` (도입 반려)**: Metal 컨텍스트를 강제하여 복잡한 벡터 뷰에는 유리하나, 이번 케이스처럼 고해상도 이미지가 빈번하게 업데이트되는 환경에서는 텍스처 갱신 오버헤드가 더 크게 작용하여 GPU Hitch가 오히려 증가(10회 -> 17회)하는 역효과를 확인했습니다.
- **`compositingGroup` (최종 적용)**: 뷰의 투명도나 블렌딩 등 레이어 합성을 렌더링 서버에서 미리 처리하도록 최적화하는 방식으로, 현재 애니메이션 구조에서 가장 안정적인 GPU Hitch 감소 효과(10회 -> 7회)를 이끌어내어 최종 적용했습니다.

### 3. 구조적 동시성 적용 및 Task.sleep의 역할 변경
기존 방식의 `Task.sleep`은 애니메이션 프레임을 직접 구동하는 '엔진' 역할을 하여 심각한 성능 저하를 유발했지만, 리팩토링된 구조에서는 그 역할과 의미를 근본적으로 개선했습니다.
- **기존 (명령형 Loop 기반)**: 0.05초마다 강제로 sleep에서 깨어나 `@State`를 변경하고 뷰 재계산을 유발했습니다. 이는 디스플레이의 실제 프레임 갱신 주기와 엇갈리며 잦은 Render Server 커밋을 유발해 성능 저하의 핵심 원인이 되었습니다.
- **개선 (선언적 KeyframeAnimator 기반)**: 애니메이션의 프레임 진행은 전적으로 `KeyframeAnimator`가 담당합니다. 이제 `Task.sleep`은 애니메이션 구동에 일절 개입하지 않으며, 오직 전체 애니메이션 지속 시간이 끝나는 시점에 맞추어 최종 결과 화면으로 상태를 전이시키는 **'비즈니스 로직의 트리거'** 역할만 수행합니다. 
- **구조적 취소 (Cancellation)**: `.task(id: animationTaskID)`를 통해 사용자가 Skip 버튼을 누를 경우, 대기 중이던 비동기 Task가 즉시 시스템 적으로 안전하게 취소(Cancel)되어 리소스 누수를 방지합니다.

## 📸 스크린샷
### 1. 개선 전 성능
| Commits (CPU) | GPU Rendering Hitch |
| :--: | :--: |
| <img width="1020" height="732" alt="개선 전 Commits" src="https://github.com/user-attachments/assets/4ce03795-8112-4e75-ba8a-4ecc2c02abd0" /> | <img width="1020" height="732" alt="개선 전 GPU Hitch" src="https://github.com/user-attachments/assets/c20fd8f1-e56e-42e7-a70b-45344992b3ab" /> |

### 2. KeyframeAnimator 성능 (최종 결정)
| Commits (CPU) | GPU Rendering Hitch |
| :--: | :--: |
| <img width="1022" height="758" alt="KeyframeAnimator Commits" src="https://github.com/user-attachments/assets/b0e2346b-c833-45cb-8b64-adf590e7279d" /><br/>*SwiftUI 루프 대비 커밋 빈도 급감* | <img width="1022" height="758" alt="KeyframeAnimator GPU Hitch" src="https://github.com/user-attachments/assets/61d0fc94-fa7f-483d-aee3-86b874ac3366" /><br/>*안정적인 프레임 유지* |

### 3. Layer Optimization 비교
| 개선 전 | drawingGroup (부적합) | compositingGroup (선택) |
| :--: | :--: | :--: |
| <img width="1020" height="732" alt="개선 전 GPU Hitch" src="https://github.com/user-attachments/assets/ff5a91a3-a5d3-40d0-973b-db4d208f5707" /><br/>*GPU Hitch 10회*| <img width="1022" height="758" alt="drawingGroup GPU Hitch" src="https://github.com/user-attachments/assets/823261ad-ae7b-4261-ba72-5c7f551685d9" /><br/>*GPU Hitch 17회*<br/>*Complex Layer Tree 5회* | <img width="1022" height="758" alt="compositingGroup GPU Hitch" src="https://github.com/user-attachments/assets/48a4050e-f915-4ea2-aed8-76296fdb080e" /><br/>*GPU Hitch 7회*<br/>*Complex Layer Tree 1회* |
| | *텍스처 갱신 오버헤드로 Hitch 발생* | *가장 매끄러운 렌더링 결과* |

### 성능 측정 간 스크린 녹화
#### 개선 전
https://github.com/user-attachments/assets/b1cfe1a8-9ea7-4092-9d20-d2af414bb56a

#### drawingGroup
https://github.com/user-attachments/assets/5cf54c77-2abb-415e-8372-9304aa454650

#### compositingGroup
https://github.com/user-attachments/assets/827337b0-fb4b-4d6f-88cf-d49a946761e0

#### KeyframeAnimator
https://github.com/user-attachments/assets/bb6588aa-fb6c-46a6-9356-d8c1e59f217d

## 🧪 성능 측정 환경
- **기기**: iPhone 16 Pro (실기기)
- **OS**: iOS 26.2
- **방법**: `Instruments` (Animation Hitches, Core Animation Commits, Frame Lifetimes, Points of Interest) 프로파일을 사용하여 상점에서 뽑기 버튼 1회 클릭 시 발생하는 10회 연속 애니메이션 수동 측정.
- **환경**: 네트워크 통신 코드를 제거한 `StoreViewModel` 코드 환경에서 수행

## 💬 리뷰 요구사항 (Optional)
- `KeyframeTrack` 분리 시 컴파일러 타입 추론 이슈로 인해 for 문을 사용하지 못하여 함수 형태(`@KeyframesBuilder`)로 쪼개어 가독성을 확보했습니다.

## ✅ 체크리스트
- [x] 빌드 및 실행 테스트를 완료했나요?
- [x] 불필요한 주석 및 Print 문을 제거했나요?
- [x] 코딩 컨벤션을 준수했나요?
