### PR TITLE
[#345] 뽑기 버튼 연속 클릭 이슈 수정

### DIFF
--- a/Damago/Damago/Sources/Presentation/Features/Collection/Store/StoreViewModel.swift
+++ b/Damago/Damago/Sources/Presentation/Features/Collection/Store/StoreViewModel.swift
@@ -84,9 +84,10 @@ final class StoreViewModel: ViewModel {
         }
         
         state.isLoading = true
-        defer { state.isLoading = false }
         
         Task {
+            defer { state.isLoading = false }
+            
             do {
                 state.drawResult = try await createDamagoUseCase.execute()
             } catch {

--- a/Damago/Damago/Sources/Presentation/Features/Collection/Store/StoreViewModel.swift
+++ b/Damago/Damago/Sources/Presentation/Features/Collection/Store/StoreViewModel.swift
@@ -78,6 +78,8 @@ final class StoreViewModel: ViewModel {
     }
     
     private func tryDraw() {
+        guard !state.isLoading else { return }
+        
         guard state.coinAmount >= StorePolicy.drawCost else {
             state.error = Pulse(.notEnoughCoin)
             return

--- a/Damago/DamagoViewModelTests/StoreViewModelTests.swift
+++ b/Damago/DamagoViewModelTests/StoreViewModelTests.swift
@@ -279,4 +279,49 @@ final class StoreViewModelTests {
             await iterator.next()
         }
     }
+
+    @Test("뽑기 작업이 진행 중일 때 들어온 추가 뽑기 요청은 무시되어야 한다")
+    func test_중복_뽑기_요청_무시() async {
+        // Given
+        let mockGlobalStore = MockGlobalStore()
+        let mockCreateDamagoUseCase = MockCreateDamagoUseCase()
+        let viewModel = StoreViewModel(
+            globalStore: mockGlobalStore,
+            createDamagoUseCase: mockCreateDamagoUseCase
+        )
+        
+        // 실행 횟수 추적
+        var executionCount = 0
+        let (stream, continuation) = AsyncStream<Void>.makeStream()
+        mockCreateDamagoUseCase.onExecute = { 
+            executionCount += 1
+            continuation.yield(())
+        }
+        mockCreateDamagoUseCase.executeResult = .success(DrawResult(damagoType: .basicBlack, isNew: true))
+        
+        let initialState = GlobalState(
+            nickname: nil, opponentName: nil, useFCM: false, useLiveActivity: false, todayPokeCount: 0,
+            coupleID: nil, totalCoin: 1000, foodCount: nil, anniversaryDate: nil, currentQuestionID: nil,
+            damagoID: nil, damagoName: nil, damagoType: nil, level: nil, currentExp: nil, maxExp: nil,
+            isHungry: nil, statusMessage: nil, lastFedAt: nil, totalPlayTime: nil, lastActiveAt: nil, ownedDamagos: [:]
+        )
+        mockGlobalStore.updateState(initialState)
+        
+        let testInput = TestInput()
+        _ = viewModel.transform(testInput.input)
+        
+        // When
+        // 1. 첫 번째 탭 전송
+        testInput.drawButtonDidTap.send(())
+        
+        // 2. UseCase가 실행될 때까지 대기
+        var iterator = stream.makeAsyncIterator()
+        await iterator.next() 
+        
+        // 3. 로딩 중인 상태에서 두 번째 탭 전송
+        testInput.drawButtonDidTap.send(())
+        
+        // Then
+        #expect(executionCount == 1, "로딩 중에는 추가 요청이 무시되어야 함")
+    }
 }


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)를 적어주세요. 해당 이슈가 존재하지 않으면 생략 가능합니다.-->
- resolves #345

## 🥑 작업 요약
<!-- 이번 PR에서 작업한 내용을 간략하게 설명해주세요.-->
- 뽑기 버튼 상태 관리 수정
  - 비동기 작업 이후 false 로 변경
  - 검증 테스트 코드 추가

## 🛠️ 작업 내용
<!-- 어떻게 보다는 '왜' 이렇게 수정했는지, 의도를 중심으로 작성해주세요.
- 개발 과정에서 발생한 문제와 해결 방법, 대안 등을 정리하면 좋습니다.-->

### 뽑기 버튼 연속 동작
- 뽑기 애니메이션 출력 전 버튼이 연속으로 클릭되면 동작되는 오류를 수정하였습니다.
- #344 의 [25f9cf4ab8186072dc06da1944289b5ca6272388](https://github.com/boostcampwm2025/ios02-damago/pull/344/changes/25f9cf4ab8186072dc06da1944289b5ca6272388) 커밋에서 수정되었으나 #342 를 머지하면서 덮어씌워져 발생한 오류였습니다.
- Task 작업이 호출되고 fire and forget 과정에서 바로 loading 을 false 로 만들기 때문에 Task 작업에서 loading 을 false 로 만들도록 수정하였습니다.

### 테스트 검증
- 기존 테스트 코드로는 iterator.next() 를 사용하여 drawResult 의 상태가 변할 때까지 기다리기 때문에 검증되지 못하였습니다. 😭
- 따라서, 다음의 테스트 코드 `@Test("뽑기 작업이 진행 중일 때 들어온 추가 뽑기 요청은 무시되어야 한다")` 를 추가하여 이러한 실수가 사전에 확인될 수 있도록 안정성을 높였습니다.

## 🧪 테스트 방법
<!-- 리뷰어가 변경 사항을 확인할 수 있는 방법을 서술합니다. -->
- 뽑기 버튼을 광클했을 때 애니메이션이 겹치는 지 확인합니다.
- 추가된 테스트가 통과되는지 확인합니다.

## ✅ 체크리스트
- [x] 빌드 및 실행 테스트를 완료했나요?
- [x] 불필요한 주석 및 Print 문을 제거했나요?
- [x] 코딩 컨벤션을 준수했나요?
