### PR TITLE
[#347] 사용자 피드백 - 설정 탭 진입 크래시

### DIFF
--- a/Damago/Damago/Sources/Presentation/Features/Collection/CollectionViewModel.swift
+++ b/Damago/Damago/Sources/Presentation/Features/Collection/CollectionViewModel.swift
@@ -58,7 +58,7 @@ final class CollectionViewModel: ViewModel {
             .store(in: &cancellables)
 
         globalStore.globalState
-            .map { $0.ownedDamagos ?? [:] }
+            .mapForUI { $0.ownedDamagos ?? [:] }
             .assign(to: \.state.ownedDamagos, on: self)
             .store(in: &cancellables)
 

--- a/Damago/Damago/Sources/Presentation/Features/Collection/Store/StoreViewModel.swift
+++ b/Damago/Damago/Sources/Presentation/Features/Collection/Store/StoreViewModel.swift
@@ -65,15 +65,14 @@ final class StoreViewModel: ViewModel {
             .store(in: &cancellables)
         
         globalStore.globalState
-            .map { $0.ownedDamagos ?? [:] }
+            .mapForUI { $0.ownedDamagos ?? [:] }
             .assign(to: \.state.ownedDamagos, on: self)
             .store(in: &cancellables)
-        
+
         globalStore.globalState
-            .map { $0.totalCoin ?? 0 }
+            .mapForUI { $0.totalCoin ?? 0 }
             .assign(to: \.state.coinAmount, on: self)
-            .store(in: &cancellables)
-        
+            .store(in: &cancellables)        
         return $state.eraseToAnyPublisher()
     }
     

--- a/Damago/Damago/Sources/Presentation/Features/Home/HomeViewModel.swift
+++ b/Damago/Damago/Sources/Presentation/Features/Home/HomeViewModel.swift
@@ -200,7 +200,7 @@ final class HomeViewModel: ViewModel {
 
     private func bindGlobalState() {
         globalStore.globalState
-            .compactMap { $0.damagoID }
+            .compactMapForUI { $0.damagoID }
             .sink { [weak self] in self?.damagoID = $0 }
             .store(in: &cancellables)
 
@@ -215,7 +215,7 @@ final class HomeViewModel: ViewModel {
             .store(in: &cancellables)
         
         globalStore.globalState
-            .map { $0.ownedDamagos ?? [:] }
+            .mapForUI { $0.ownedDamagos ?? [:] }
             .assign(to: \.state.ownedDamagos, on: self)
             .store(in: &cancellables)
 
@@ -230,7 +230,7 @@ final class HomeViewModel: ViewModel {
             .store(in: &cancellables)
 
         globalStore.globalState
-            .compactMap { $0.currentExp }
+            .compactMapForUI { $0.currentExp }
             .sink { [weak self] in self?.state.currentExp = $0 }
             .store(in: &cancellables)
 
@@ -264,7 +264,7 @@ final class HomeViewModel: ViewModel {
             .store(in: &cancellables)
 
         globalStore.globalState
-            .map { $0.todayPokeCount }
+            .mapForUI { $0.todayPokeCount }
             .sink { [weak self] in self?.state.todayPokeCount = $0 }
             .store(in: &cancellables)
     }

--- a/Damago/Damago/Sources/Presentation/Features/Interaction/InteractionViewModel.swift
+++ b/Damago/Damago/Sources/Presentation/Features/Interaction/InteractionViewModel.swift
@@ -97,21 +97,21 @@ final class InteractionViewModel: ViewModel {
         return $state.eraseToAnyPublisher()
     }
 
-    // swiftlint:disable trailing_closure
     private func bindGlobalStore() {
         globalStore.globalState
-            .handleEvents(receiveOutput: { [weak self] state in
-                self?.coupleID = state.coupleID
-            })
             .compactMapForUI { $0.coupleID }
-            .first()
-            .sink { [weak self] _ in
-                self?.fetchDailyQuestionData()
-                self?.fetchBalanceGameData()
+            .sink { [weak self] coupleID in
+                guard let self else { return }
+                let isFirstTime = self.coupleID == nil
+                self.coupleID = coupleID
+                
+                if isFirstTime {
+                    self.fetchDailyQuestionData()
+                    self.fetchBalanceGameData()
+                }
             }
             .store(in: &cancellables)
     }
-    // swiftlint:enable trailing_closure
 
     // MARK: - Daily Question
     private func fetchDailyQuestionData() {

--- a/Damago/Damago/Sources/Presentation/Features/Onboarding/DamagoSetup/DamagoSetupViewModel.swift
+++ b/Damago/Damago/Sources/Presentation/Features/Onboarding/DamagoSetup/DamagoSetupViewModel.swift
@@ -60,7 +60,7 @@ final class DamagoSetupViewModel: ViewModel {
             .store(in: &cancellables)
 
         globalStore.globalState
-            .map { $0.ownedDamagos ?? [:] }
+            .mapForUI { $0.ownedDamagos ?? [:] }
             .assign(to: \.state.ownedDamagos, on: self)
             .store(in: &cancellables)
 

--- a/Damago/Damago/Sources/Presentation/Features/Settings/SettingsViewController.swift
+++ b/Damago/Damago/Sources/Presentation/Features/Settings/SettingsViewController.swift
@@ -184,14 +184,14 @@ final class SettingsViewController: UIViewController {
         let popupView = DamagoBackgroundColorPopupView(initialOption: current)
         popupView.translatesAutoresizingMaskIntoConstraints = false
 
-        let targetView = tabBarController?.view ?? view
-        targetView?.addSubview(popupView)
+        guard let targetView = tabBarController?.view ?? view else { return }
+        targetView.addSubview(popupView)
 
         NSLayoutConstraint.activate([
-            popupView.topAnchor.constraint(equalTo: targetView!.topAnchor),
-            popupView.leadingAnchor.constraint(equalTo: targetView!.leadingAnchor),
-            popupView.trailingAnchor.constraint(equalTo: targetView!.trailingAnchor),
-            popupView.bottomAnchor.constraint(equalTo: targetView!.bottomAnchor)
+            popupView.topAnchor.constraint(equalTo: targetView.topAnchor),
+            popupView.leadingAnchor.constraint(equalTo: targetView.leadingAnchor),
+            popupView.trailingAnchor.constraint(equalTo: targetView.trailingAnchor),
+            popupView.bottomAnchor.constraint(equalTo: targetView.bottomAnchor)
         ])
 
         popupView.confirmButtonTappedSubject
@@ -339,6 +339,8 @@ extension SettingsViewController: UIPopoverPresentationControllerDelegate {
 
         // 다이내믹 아일랜드(Live Activity) 토글 셀 찾기
         let snapshot = dataSource.snapshot()
+        guard snapshot.sectionIdentifiers.contains(.preferences) else { return }
+        
         let items = snapshot.itemIdentifiers(inSection: .preferences)
         
         guard let liveActivityItem = items.first(where: {

--- a/Damago/Damago/Sources/Presentation/Features/Settings/SettingsViewModel.swift
+++ b/Damago/Damago/Sources/Presentation/Features/Settings/SettingsViewModel.swift
@@ -89,6 +89,7 @@ final class SettingsViewModel: ViewModel {
 
     func transform(_ input: Input) -> AnyPublisher<State, Never> {
         input.viewDidLoad
+            .receive(on: DispatchQueue.main)
             .sink { [weak self] in
                 self?.loadDamagoBackgroundOption()
                 self?.refreshPermissionsAndBind()
@@ -96,24 +97,28 @@ final class SettingsViewModel: ViewModel {
             .store(in: &cancellables)
 
         input.toggleChanged
+            .receive(on: DispatchQueue.main)
             .sink { [weak self] type, isOn in
                 self?.handleToggle(type: type, isOn: isOn)
             }
             .store(in: &cancellables)
 
         input.itemSelected
+            .receive(on: DispatchQueue.main)
             .sink { [weak self] item in
                 self?.handleSelection(item: item)
             }
             .store(in: &cancellables)
 
         input.damagoBackgroundChanged
+            .receive(on: DispatchQueue.main)
             .sink { [weak self] option in
                 self?.handleDamagoBackgroundChange(option)
             }
             .store(in: &cancellables)
 
         input.alertActionDidConfirm
+            .receive(on: DispatchQueue.main)
             .sink { [weak self] type in
                 self?.performAction(type)
             }
@@ -125,9 +130,13 @@ final class SettingsViewModel: ViewModel {
     private func refreshPermissionsAndBind() {
         Task {
             let notiSettings = await UNUserNotificationCenter.current().notificationSettings()
-            state.notificationCurrentPermission = (notiSettings.authorizationStatus == .authorized)
-            state.activityCurrentPermission = ActivityAuthorizationInfo().areActivitiesEnabled
-            bindGlobalState()
+            let activityEnabled = ActivityAuthorizationInfo().areActivitiesEnabled
+            
+            await MainActor.run {
+                state.notificationCurrentPermission = (notiSettings.authorizationStatus == .authorized)
+                state.activityCurrentPermission = activityEnabled
+                bindGlobalState()
+            }
         }
     }
 
@@ -162,6 +171,7 @@ final class SettingsViewModel: ViewModel {
 
         globalStore.globalState
             .compactMap { $0.anniversaryDate }
+            .receive(on: DispatchQueue.main)
             .sink { [weak self] date in
                 self?.state.anniversaryDate = date.toString()
                 self?.state.dDay = date.daysBetween(to: Date()) ?? 0

--- a/Damago/Damago/Sources/Presentation/Shared/Utils/Combine+.swift
+++ b/Damago/Damago/Sources/Presentation/Shared/Utils/Combine+.swift
@@ -22,11 +22,19 @@ struct Pulse<R>: Equatable {
 }
 
 extension Publisher where Failure == Never {
+    func receiveOnMainIfNecessary() -> AnyPublisher<Output, Failure> {
+        if Thread.isMainThread {
+            return self.eraseToAnyPublisher()
+        } else {
+            return self.receive(on: DispatchQueue.main).eraseToAnyPublisher()
+        }
+    }
+
     func mapForUI<T: Equatable>(
         _ transform: @escaping (Output) -> T
     ) -> AnyPublisher<T, Failure> {
         self
-            .receive(on: DispatchQueue.main)
+            .receiveOnMainIfNecessary()
             .map(transform)
             .removeDuplicates()
             .eraseToAnyPublisher()
@@ -37,7 +45,7 @@ extension Publisher where Failure == Never {
         isDuplicate: @escaping (T, T) -> Bool
     ) -> AnyPublisher<T, Failure> {
         self
-            .receive(on: DispatchQueue.main)
+            .receiveOnMainIfNecessary()
             .map(transform)
             .removeDuplicates(by: isDuplicate)
             .eraseToAnyPublisher()
@@ -47,7 +55,7 @@ extension Publisher where Failure == Never {
         _ transform: @escaping (Output) -> T?
     ) -> AnyPublisher<T, Failure> {
         self
-            .receive(on: DispatchQueue.main)
+            .receiveOnMainIfNecessary()
             .compactMap(transform)
             .removeDuplicates()
             .eraseToAnyPublisher()
@@ -58,7 +66,7 @@ extension Publisher where Failure == Never {
         isDuplicate: @escaping (T, T) -> Bool
     ) -> AnyPublisher<T, Failure> {
         self
-            .receive(on: DispatchQueue.main)
+            .receiveOnMainIfNecessary()
             .compactMap(transform)
             .removeDuplicates(by: isDuplicate)
             .eraseToAnyPublisher()
@@ -68,7 +76,7 @@ extension Publisher where Failure == Never {
         _ keyPath: KeyPath<Output, Pulse<R>?>
     ) -> AnyPublisher<R, Failure> {
         self
-            .receive(on: DispatchQueue.main)
+            .receiveOnMainIfNecessary()
             .map(keyPath)
             .removeDuplicates()
             .compactMap { $0?.value }

--- a/Damago/Damago/Sources/Presentation/Shared/Utils/Combine+.swift
+++ b/Damago/Damago/Sources/Presentation/Shared/Utils/Combine+.swift
@@ -26,9 +26,9 @@ extension Publisher where Failure == Never {
         _ transform: @escaping (Output) -> T
     ) -> AnyPublisher<T, Failure> {
         self
+            .receive(on: DispatchQueue.main)
             .map(transform)
             .removeDuplicates()
-            .receive(on: DispatchQueue.main)
             .eraseToAnyPublisher()
     }
 
@@ -37,9 +37,9 @@ extension Publisher where Failure == Never {
         isDuplicate: @escaping (T, T) -> Bool
     ) -> AnyPublisher<T, Failure> {
         self
+            .receive(on: DispatchQueue.main)
             .map(transform)
             .removeDuplicates(by: isDuplicate)
-            .receive(on: DispatchQueue.main)
             .eraseToAnyPublisher()
     }
 
@@ -47,9 +47,9 @@ extension Publisher where Failure == Never {
         _ transform: @escaping (Output) -> T?
     ) -> AnyPublisher<T, Failure> {
         self
+            .receive(on: DispatchQueue.main)
             .compactMap(transform)
             .removeDuplicates()
-            .receive(on: DispatchQueue.main)
             .eraseToAnyPublisher()
     }
 
@@ -58,9 +58,9 @@ extension Publisher where Failure == Never {
         isDuplicate: @escaping (T, T) -> Bool
     ) -> AnyPublisher<T, Failure> {
         self
+            .receive(on: DispatchQueue.main)
             .compactMap(transform)
             .removeDuplicates(by: isDuplicate)
-            .receive(on: DispatchQueue.main)
             .eraseToAnyPublisher()
     }
 
@@ -68,10 +68,10 @@ extension Publisher where Failure == Never {
         _ keyPath: KeyPath<Output, Pulse<R>?>
     ) -> AnyPublisher<R, Failure> {
         self
+            .receive(on: DispatchQueue.main)
             .map(keyPath)
             .removeDuplicates()
             .compactMap { $0?.value }
-            .receive(on: DispatchQueue.main)
             .eraseToAnyPublisher()
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈
- resolves #347

## 🥑 작업 요약
- 설정 탭 진입 시 발생하는 크래시 현상을 수정
- 프로젝트 전역의 Combine 유틸리티를 리팩토링하여 `@MainActor` 기반 ViewModel의 스레드 안전성을 근본적으로 강화
- 주요 ViewModel의 백그라운드 스레드에서의 상태 변경 위험을 제거

## 🛠️ 작업 내용
### SettingsViewController 안정성 확보

- `setupTips()`에서 스냅샷 섹션 존재 여부 체크 로직을 추가하여 데이터 미로드 시의 `NSInternalInconsistencyException` 방지했습니다.
- 배경색 팝업 노출 시 강제 언래핑 제거 및 방어적 코드 적용했습니다.

### Combine+.swift` 유틸리티 근본 리팩토링 및 테스트 호환성 확보

- `mapForUI`, `compactMapForUI`, `pulse` 등의 커스텀 연산자 내부에서 `receiveOnMainIfNecessary()`를 호출하여 체인 최상단에서 스레드 관리합니다.
- **테스트 호환성**: 현재 스레드가 이미 메인일 경우 즉시 실행되도록 개선하여, 비동기 처리를 기다리지 않는 기존 단위 테스트들과의 호환성을 유지하면서도 앱 런타임의 안전성을 확보했습니다.
- 이를 통해 변환 클로저 내부에서도 안전하게 `@MainActor` 격리 속성(ViewModel의 `state` 등)에 접근할 수 있도록 개선했습니다.

### 전역 ViewModel 스레드 안전성 점검 및 수정

- `GlobalStore` 등 백그라운드 발생 가능성이 있는 업스트림 구독 시 메인 스레드 전환을 보장하도록 수정했습니다.
- 중복된 `.receive(on: .main)` 코드를 제거하고 개선된 `*ForUI` 유틸리티로 코드 최적화했습니다.

## 📸 스크린샷

https://github.com/user-attachments/assets/d207cd3c-9644-4037-931e-fd9490f8a735

## 🧪 테스트 방법
- [x] 앱 실행 후 즉시 설정 탭 진입 시 크래시 여부 확인
- [x] 네트워크 속도를 지연시킨 상태에서 설정 탭 진입 시 안정성 확인
- [x] 다이내믹 아일랜드 설정 토글 및 배경색 변경 팝업 정상 작동 확인

## ✅ 체크리스트
- [x] 빌드 및 실행 테스트를 완료했나요?
- [x] 불필요한 주석 및 Print 문을 제거했나요?
- [x] 코딩 컨벤션을 준수했나요?
